### PR TITLE
fix(picker): fix RangePicker value sync bug when start date is larger…

### DIFF
--- a/packages/picker/src/PickerInput/hooks/useRangeValue.ts
+++ b/packages/picker/src/PickerInput/hooks/useRangeValue.ts
@@ -243,6 +243,10 @@ export default function useRangeValue<ValueType extends DateType[], DateType ext
       // Sync value with submit value
       setInnerValue(clone)
 
+      // submitValue.value is old value, setInnerValue is new value,
+      // so we need to sync submitValue.value to new value.
+      submitValue.value = clone
+
       const [isSameMergedDates] = isSameDates(clone, oldValue)
       // Trigger `onChange` if needed
       if (onChange && !isSameMergedDates) {


### PR DESCRIPTION
- Optimistically update `submitValue` in `useRangeValue` to prevent stale state usage during subsequent updates (e.g. blur events).