### PR TITLE
fix(select): show placeholder when value is empty string

### DIFF
--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -356,7 +356,7 @@ const Select = defineComponent<SelectProps>({
       if (!props.mode && mergedValues.value.length === 1) {
         const firstValue = mergedValues.value[0]
         if (
-          firstValue.value === null
+          (firstValue.value === null || firstValue.value === '')
           && (firstValue.label === null || firstValue.label === undefined)
         ) {
           return []


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

close antdv-next/antdv-next#184

### 💡 Background and Solution

**Problem:** When using `v-model:value` with an empty string initial value — a very common Vue pattern like `ref({ name: '' })` — the Select component has two visual issues:

1. **Placeholder disappears** — the "请选择" text is not shown
2. **Size shrinks** — the select box renders an empty selected state instead of placeholder, causing visual size reduction

**Root cause:** The `displayValues` computation in `Select.tsx` only treated `value === null` as "no selection, show placeholder". When `value === ''` (empty string) with no matching option, it was incorrectly treated as a selected value, which:
- Adds `content-has-value` CSS class to the content area
- Renders `displayValue.label` (empty string `''`) instead of `<Placeholder>` component
- Results in both placeholder disappearing and visual shrinkage

**Fix:** Add `firstValue.value === ''` to the existing null check in `displayValues`:

```diff
- firstValue.value === null
+ (firstValue.value === null || firstValue.value === '')
```

The label guard (`firstValue.label === null || undefined`) ensures this only triggers when there's **no matching option** — if an option with `value: ''` exists, its label gets filled by `convert2LabelValues`, so the placeholder won't incorrectly appear.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed Select placeholder missing and size shrinking when `value` is an empty string with no matching option. |
| 🇨🇳 Chinese | 修复 Select 组件在 `value` 为空字符串且无匹配选项时 placeholder 消失、尺寸缩小的问题。 |