### PR TITLE
fix(input,textarea): add IME composition guard with changeOnComposing prop

### DIFF
--- a/packages/input/src/input.tsx
+++ b/packages/input/src/input.tsx
@@ -22,6 +22,8 @@ const Input = defineComponent<
     const focused = shallowRef(false)
     const compositionRef = shallowRef(false)
     const keyLockRef = shallowRef(false)
+    // Track the value emitted by compositionEnd to dedup Firefox's subsequent input event
+    const compositionEndValueRef = shallowRef<string | null>(null)
     const { count, showCount } = toPropsRefs(props, 'count', 'showCount')
 
     const onChange = (e: Event) => {
@@ -107,11 +109,21 @@ const Input = defineComponent<
         return
       }
 
+      // Dedup: Firefox fires input AFTER compositionend with the same value
+      if (compositionEndValueRef.value !== null) {
+        const lastValue = compositionEndValueRef.value
+        compositionEndValueRef.value = null
+        if (currentValue === lastValue) {
+          return
+        }
+      }
+
       let cutValue = currentValue
       const config = countConfig.value
 
       if (
-        config?.exceedFormatter
+        !compositionRef.value
+        && config?.exceedFormatter
         && config.max
         && config.strategy(currentValue) > config.max
       ) {
@@ -155,6 +167,8 @@ const Input = defineComponent<
       // Also skip if value hasn't changed (e.g. composition cancelled via Esc).
       if (!props.changeOnComposing && currentValue !== formatValue.value) {
         triggerChange(e, currentValue)
+        // Mark for dedup: Firefox fires input AFTER compositionend with same value
+        compositionEndValueRef.value = currentValue
       }
       props?.onCompositionEnd?.(e as any)
     }

--- a/packages/input/src/input.tsx
+++ b/packages/input/src/input.tsx
@@ -147,10 +147,15 @@ const Input = defineComponent<
 
     const onInternalCompositionEnd = (e: CompositionEvent) => {
       compositionRef.value = false
-      // Must trigger change here because in Chrome/Safari the final input event
-      // fires BEFORE compositionend (while compositionRef is still true),
-      // and no additional input event fires after compositionend.
-      triggerChange(e, (e.target as HTMLInputElement).value)
+      const currentValue = (e.target as HTMLInputElement).value
+      // When changeOnComposing is true, the input event before compositionend
+      // already fired onChange with the final value — skip to avoid duplicate.
+      // When guard is on (default), the input event was blocked, so we must
+      // trigger here as Chrome/Safari fire input BEFORE compositionend.
+      // Also skip if value hasn't changed (e.g. composition cancelled via Esc).
+      if (!props.changeOnComposing && currentValue !== formatValue.value) {
+        triggerChange(e, currentValue)
+      }
       props?.onCompositionEnd?.(e as any)
     }
 

--- a/packages/input/src/input.tsx
+++ b/packages/input/src/input.tsx
@@ -109,13 +109,13 @@ const Input = defineComponent<
         return
       }
 
-      // Dedup: Firefox fires input AFTER compositionend with the same value
+      // Dedup: Firefox fires input event(s) AFTER compositionend with the same value.
+      // Keep blocking until a genuinely different value arrives.
       if (compositionEndValueRef.value !== null) {
-        const lastValue = compositionEndValueRef.value
-        compositionEndValueRef.value = null
-        if (currentValue === lastValue) {
+        if (currentValue === compositionEndValueRef.value) {
           return
         }
+        compositionEndValueRef.value = null
       }
 
       let cutValue = currentValue
@@ -167,7 +167,10 @@ const Input = defineComponent<
       // Also skip if value hasn't changed (e.g. composition cancelled via Esc).
       if (!props.changeOnComposing && currentValue !== formatValue.value) {
         triggerChange(e, currentValue)
-        // Mark for dedup: Firefox fires input AFTER compositionend with same value
+      }
+      // Always set dedup ref after compositionend: Firefox fires input event(s)
+      // after compositionend regardless of whether value changed or not
+      if (!props.changeOnComposing) {
         compositionEndValueRef.value = currentValue
       }
       props?.onCompositionEnd?.(e as any)

--- a/packages/input/src/input.tsx
+++ b/packages/input/src/input.tsx
@@ -154,6 +154,8 @@ const Input = defineComponent<
 
     const onInternalCompositionStart = (e: CompositionEvent) => {
       compositionRef.value = true
+      // Clear stale dedup marker from previous composition cycle
+      compositionEndValueRef.value = null
       props?.onCompositionStart?.(e as any)
     }
 
@@ -208,6 +210,7 @@ const Input = defineComponent<
     }
 
     const handleReset = (e: MouseEvent) => {
+      compositionEndValueRef.value = null
       if (props.value === undefined) {
         value.value = ''
       }

--- a/packages/input/src/input.tsx
+++ b/packages/input/src/input.tsx
@@ -1,6 +1,6 @@
 import type { InputFocusOptions } from '@v-c/util/dist/Dom/focus'
 import type { HolderRef } from './BaseInput'
-import type { ChangeEventInfo, InputProps } from './interface'
+import type { InputProps } from './interface'
 import { clsx } from '@v-c/util'
 import { triggerFocus } from '@v-c/util/dist/Dom/focus'
 import { KeyCodeStr } from '@v-c/util/dist/KeyCode'
@@ -101,14 +101,17 @@ const Input = defineComponent<
     const triggerChange = (
       e: Event | CompositionEvent,
       currentValue: string,
-      info: ChangeEventInfo,
     ) => {
+      // Skip during IME composition to avoid emitting intermediate values
+      if (compositionRef.value && !props.changeOnComposing) {
+        return
+      }
+
       let cutValue = currentValue
       const config = countConfig.value
 
       if (
-        !compositionRef.value
-        && config?.exceedFormatter
+        config?.exceedFormatter
         && config.max
         && config.strategy(currentValue) > config.max
       ) {
@@ -123,9 +126,6 @@ const Input = defineComponent<
           ]
         }
       }
-      else if (info.source === 'compositionEnd') {
-        return
-      }
 
       if (props.value === undefined) {
         value.value = cutValue
@@ -137,9 +137,7 @@ const Input = defineComponent<
     }
 
     const onInternalChange = (e: Event) => {
-      triggerChange(e, (e.target as HTMLInputElement).value, {
-        source: 'change',
-      })
+      triggerChange(e, (e.target as HTMLInputElement).value)
     }
 
     const onInternalCompositionStart = (e: CompositionEvent) => {
@@ -149,9 +147,10 @@ const Input = defineComponent<
 
     const onInternalCompositionEnd = (e: CompositionEvent) => {
       compositionRef.value = false
-      triggerChange(e, (e.target as HTMLInputElement).value, {
-        source: 'compositionEnd',
-      })
+      // Must trigger change here because in Chrome/Safari the final input event
+      // fires BEFORE compositionend (while compositionRef is still true),
+      // and no additional input event fires after compositionend.
+      triggerChange(e, (e.target as HTMLInputElement).value)
       props?.onCompositionEnd?.(e as any)
     }
 
@@ -305,6 +304,7 @@ const Input = defineComponent<
           'onCompositionStart',
           'onCompositionEnd',
           'onInput',
+          'changeOnComposing',
         ],
       )
 

--- a/packages/input/src/interface.ts
+++ b/packages/input/src/interface.ts
@@ -139,6 +139,12 @@ export interface InputProps extends Omit<CommonInputProps, 'classNames' | 'style
   onKeyUp?: KeyboardEventHandler
   onCompositionStart?: CompositionEventHandler
   onCompositionEnd?: CompositionEventHandler
+  /**
+   * Whether to trigger onChange during IME composition.
+   * When false (default), onChange only fires after compositionEnd with the final value.
+   * When true, onChange fires on every keystroke including intermediate IME values.
+   */
+  changeOnComposing?: boolean
   components?: BaseInputProps['components']
   dataAttrs?: BaseInputProps['dataAttrs']
 }
@@ -156,6 +162,3 @@ export interface InputRef {
   nativeElement: HTMLElement | null
 }
 
-export interface ChangeEventInfo {
-  source: 'compositionEnd' | 'change'
-}

--- a/packages/input/tests/composition.test.tsx
+++ b/packages/input/tests/composition.test.tsx
@@ -57,8 +57,9 @@ describe('input IME composition guard', () => {
     await input.trigger('compositionend')
     await nextTick()
 
-    // compositionend also triggers onChange
-    expect(onChange).toHaveBeenCalledTimes(4)
+    // compositionend skips triggerChange when changeOnComposing is true
+    // (the input event before compositionend already handled the final value)
+    expect(onChange).toHaveBeenCalledTimes(3)
   })
 
   it('should trigger onChange normally for non-IME input', async () => {

--- a/packages/input/tests/composition.test.tsx
+++ b/packages/input/tests/composition.test.tsx
@@ -62,6 +62,61 @@ describe('input IME composition guard', () => {
     expect(onChange).toHaveBeenCalledTimes(3)
   })
 
+  it('should dedup Firefox compositionend→input sequence (default mode)', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount(Input, {
+      props: { onChange },
+    })
+    const input = wrapper.find('input')
+    const inputEl = input.element as HTMLInputElement
+
+    // Simulate Firefox event order: compositionend fires BEFORE the final input
+    await input.trigger('compositionstart')
+    inputEl.value = 'h'
+    await input.trigger('input')
+    inputEl.value = 'he'
+    await input.trigger('input')
+    inputEl.value = 'hei'
+    await input.trigger('input')
+
+    expect(onChange).not.toHaveBeenCalled()
+
+    // Firefox: compositionend first
+    inputEl.value = '黑'
+    await input.trigger('compositionend')
+    await nextTick()
+    expect(onChange).toHaveBeenCalledTimes(1)
+
+    // Firefox: then input with same value — should be deduped
+    await input.trigger('input')
+    await nextTick()
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not run exceedFormatter during composition (changeOnComposing=true)', async () => {
+    const onChange = vi.fn()
+    const exceedFormatter = vi.fn((val: string) => val.slice(0, 2))
+    const wrapper = mount(Input, {
+      props: {
+        onChange,
+        changeOnComposing: true,
+        count: { max: 2, strategy: (v: string) => v.length, exceedFormatter },
+      },
+    })
+    const input = wrapper.find('input')
+    const inputEl = input.element as HTMLInputElement
+
+    await input.trigger('compositionstart')
+    inputEl.value = 'hei'
+    await input.trigger('input')
+
+    // exceedFormatter should NOT be called during composition
+    // even though 'hei' exceeds max=2
+    expect(exceedFormatter).not.toHaveBeenCalled()
+    // onChange still fires (changeOnComposing=true)
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
   it('should trigger onChange normally for non-IME input', async () => {
     const onChange = vi.fn()
     const wrapper = mount(Input, {

--- a/packages/input/tests/composition.test.tsx
+++ b/packages/input/tests/composition.test.tsx
@@ -1,0 +1,80 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import Input from '../src/input'
+
+describe('input IME composition guard', () => {
+  it('should NOT trigger onChange during composition by default', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount(Input, {
+      props: { onChange },
+    })
+    const input = wrapper.find('input')
+
+    // Simulate IME composition: compositionstart → input events → compositionend
+    await input.trigger('compositionstart')
+    await input.setValue('h')
+    await input.trigger('input')
+    await input.setValue('he')
+    await input.trigger('input')
+    await input.setValue('hei')
+    await input.trigger('input')
+
+    // During composition, onChange should not be called
+    expect(onChange).not.toHaveBeenCalled()
+
+    // compositionend with final value
+    const inputEl = input.element as HTMLInputElement
+    inputEl.value = '黑'
+    await input.trigger('compositionend')
+    await nextTick()
+
+    // Only one call with the final value
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('should trigger onChange during composition when changeOnComposing is true', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount(Input, {
+      props: { onChange, changeOnComposing: true },
+    })
+    const input = wrapper.find('input')
+
+    await input.trigger('compositionstart')
+
+    const inputEl = input.element as HTMLInputElement
+    inputEl.value = 'h'
+    await input.trigger('input')
+    inputEl.value = 'he'
+    await input.trigger('input')
+    inputEl.value = 'hei'
+    await input.trigger('input')
+
+    // With changeOnComposing=true, onChange fires on every input during composition
+    expect(onChange).toHaveBeenCalledTimes(3)
+
+    inputEl.value = '黑'
+    await input.trigger('compositionend')
+    await nextTick()
+
+    // compositionend also triggers onChange
+    expect(onChange).toHaveBeenCalledTimes(4)
+  })
+
+  it('should trigger onChange normally for non-IME input', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount(Input, {
+      props: { onChange },
+    })
+    const input = wrapper.find('input')
+    const inputEl = input.element as HTMLInputElement
+
+    // Normal typing (no composition)
+    inputEl.value = 'a'
+    await input.trigger('input')
+    inputEl.value = 'ab'
+    await input.trigger('input')
+
+    expect(onChange).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/input/vitest.config.ts
+++ b/packages/input/vitest.config.ts
@@ -4,6 +4,8 @@ import configShared from '../../vitest.config'
 export default mergeConfig(
   configShared,
   defineProject({
-
+    test: {
+      environment: 'jsdom',
+    },
   }),
 )

--- a/packages/textarea/src/TextArea.tsx
+++ b/packages/textarea/src/TextArea.tsx
@@ -122,10 +122,15 @@ const TextArea = defineComponent<TextAreaProps>(
 
     const onInternalCompositionEnd = (e: any) => {
       compositionRef.value = false
-      // Must trigger change here because in Chrome/Safari the final input event
-      // fires BEFORE compositionend (while compositionRef is still true),
-      // and no additional input event fires after compositionend.
-      triggerChange(e, e.currentTarget.value)
+      const currentValue = e.currentTarget.value
+      // When changeOnComposing is true, the input event before compositionend
+      // already fired onChange with the final value — skip to avoid duplicate.
+      // When guard is on (default), the input event was blocked, so we must
+      // trigger here as Chrome/Safari fire input BEFORE compositionend.
+      // Also skip if value hasn't changed (e.g. composition cancelled via Esc).
+      if (!props.changeOnComposing && currentValue !== formatValue.value) {
+        triggerChange(e, currentValue)
+      }
     }
 
     const onInternalChange = (e: any) => {

--- a/packages/textarea/src/TextArea.tsx
+++ b/packages/textarea/src/TextArea.tsx
@@ -23,6 +23,8 @@ const TextArea = defineComponent<TextAreaProps>(
     const formatValue = computed(() => value.value === undefined || value.value === null ? '' : String(value.value))
     const focused = shallowRef(false)
     const compositionRef = shallowRef(false)
+    // Track the value emitted by compositionEnd to dedup Firefox's subsequent input event
+    const compositionEndValueRef = shallowRef<string | null>(null)
 
     const textareaResized = shallowRef<boolean>()
 
@@ -83,9 +85,19 @@ const TextArea = defineComponent<TextAreaProps>(
         return
       }
 
+      // Dedup: Firefox fires input AFTER compositionend with the same value
+      if (compositionEndValueRef.value !== null) {
+        const lastValue = compositionEndValueRef.value
+        compositionEndValueRef.value = null
+        if (currentValue === lastValue) {
+          return
+        }
+      }
+
       let cutValue = currentValue
       if (
-        countConfig.value.exceedFormatter
+        !compositionRef.value
+        && countConfig.value.exceedFormatter
         && countConfig.value.max
         && countConfig.value.strategy(currentValue) > countConfig.value.max
       ) {
@@ -130,6 +142,8 @@ const TextArea = defineComponent<TextAreaProps>(
       // Also skip if value hasn't changed (e.g. composition cancelled via Esc).
       if (!props.changeOnComposing && currentValue !== formatValue.value) {
         triggerChange(e, currentValue)
+        // Mark for dedup: Firefox fires input AFTER compositionend with same value
+        compositionEndValueRef.value = currentValue
       }
     }
 

--- a/packages/textarea/src/TextArea.tsx
+++ b/packages/textarea/src/TextArea.tsx
@@ -130,6 +130,8 @@ const TextArea = defineComponent<TextAreaProps>(
     // =========================== Value Update ===========================
     const onInternalCompositionStart = () => {
       compositionRef.value = true
+      // Clear stale dedup marker from previous composition cycle
+      compositionEndValueRef.value = null
     }
 
     const onInternalCompositionEnd = (e: any) => {
@@ -173,6 +175,7 @@ const TextArea = defineComponent<TextAreaProps>(
 
     // ============================== Reset ===============================
     const handleReset = (e: MouseEvent) => {
+      compositionEndValueRef.value = null
       value.value = ''
       focus()
       resolveOnChange(getTextArea(), e, props.onChange as unknown as any)

--- a/packages/textarea/src/TextArea.tsx
+++ b/packages/textarea/src/TextArea.tsx
@@ -78,9 +78,14 @@ const TextArea = defineComponent<TextAreaProps>(
 
     // ============================== Change ==============================
     const triggerChange = (e: any, currentValue: string) => {
+      // Skip during IME composition to avoid emitting intermediate values
+      if (compositionRef.value && !props.changeOnComposing) {
+        return
+      }
+
       let cutValue = currentValue
-      if (!compositionRef.value
-        && countConfig.value.exceedFormatter
+      if (
+        countConfig.value.exceedFormatter
         && countConfig.value.max
         && countConfig.value.strategy(currentValue) > countConfig.value.max
       ) {
@@ -101,7 +106,7 @@ const TextArea = defineComponent<TextAreaProps>(
         }
       }
       const textarea = getTextArea()
-      if (!compositionRef.value && textarea && textarea.value !== cutValue) {
+      if (textarea && textarea.value !== cutValue) {
         textarea.value = cutValue
       }
 
@@ -117,7 +122,9 @@ const TextArea = defineComponent<TextAreaProps>(
 
     const onInternalCompositionEnd = (e: any) => {
       compositionRef.value = false
-      // Trigger change event after composition end
+      // Must trigger change here because in Chrome/Safari the final input event
+      // fires BEFORE compositionend (while compositionRef is still true),
+      // and no additional input event fires after compositionend.
       triggerChange(e, e.currentTarget.value)
     }
 
@@ -258,6 +265,7 @@ const TextArea = defineComponent<TextAreaProps>(
               'onPressEnter',
               'onFocus',
               'onBlur',
+              'changeOnComposing',
             ])}
             autoSize={autoSize}
             maxLength={maxLength}

--- a/packages/textarea/src/TextArea.tsx
+++ b/packages/textarea/src/TextArea.tsx
@@ -85,13 +85,13 @@ const TextArea = defineComponent<TextAreaProps>(
         return
       }
 
-      // Dedup: Firefox fires input AFTER compositionend with the same value
+      // Dedup: Firefox fires input event(s) AFTER compositionend with the same value.
+      // Keep blocking until a genuinely different value arrives.
       if (compositionEndValueRef.value !== null) {
-        const lastValue = compositionEndValueRef.value
-        compositionEndValueRef.value = null
-        if (currentValue === lastValue) {
+        if (currentValue === compositionEndValueRef.value) {
           return
         }
+        compositionEndValueRef.value = null
       }
 
       let cutValue = currentValue
@@ -142,7 +142,10 @@ const TextArea = defineComponent<TextAreaProps>(
       // Also skip if value hasn't changed (e.g. composition cancelled via Esc).
       if (!props.changeOnComposing && currentValue !== formatValue.value) {
         triggerChange(e, currentValue)
-        // Mark for dedup: Firefox fires input AFTER compositionend with same value
+      }
+      // Always set dedup ref after compositionend: Firefox fires input event(s)
+      // after compositionend regardless of whether value changed or not
+      if (!props.changeOnComposing) {
         compositionEndValueRef.value = currentValue
       }
     }

--- a/packages/textarea/src/interface.ts
+++ b/packages/textarea/src/interface.ts
@@ -43,6 +43,12 @@ export interface TextAreaProps {
   onKeyup?: (e: KeyboardEvent) => void
   onFocus?: (e: FocusEvent) => void
   onBlur?: (e: FocusEvent) => void
+  /**
+   * Whether to trigger onChange during IME composition.
+   * When false (default), onChange only fires after compositionEnd with the final value.
+   * When true, onChange fires on every keystroke including intermediate IME values.
+   */
+  changeOnComposing?: boolean
 }
 
 export interface TextAreaRef {

--- a/packages/textarea/tests/composition.test.tsx
+++ b/packages/textarea/tests/composition.test.tsx
@@ -58,8 +58,9 @@ describe('textarea IME composition guard', () => {
     await textarea.trigger('compositionend')
     await nextTick()
 
-    // compositionend also triggers onChange
-    expect(onChange).toHaveBeenCalledTimes(4)
+    // compositionend skips triggerChange when changeOnComposing is true
+    // (the input event before compositionend already handled the final value)
+    expect(onChange).toHaveBeenCalledTimes(3)
   })
 
   it('should trigger onChange normally for non-IME input', async () => {

--- a/packages/textarea/tests/composition.test.tsx
+++ b/packages/textarea/tests/composition.test.tsx
@@ -1,0 +1,81 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import TextArea from '../src/TextArea'
+
+describe('textarea IME composition guard', () => {
+  it('should NOT trigger onChange during composition by default', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount(TextArea, {
+      props: { onChange },
+    })
+    const textarea = wrapper.find('textarea')
+
+    // Simulate IME composition
+    await textarea.trigger('compositionstart')
+
+    const el = textarea.element as HTMLTextAreaElement
+    el.value = 'h'
+    await textarea.trigger('input')
+    el.value = 'he'
+    await textarea.trigger('input')
+    el.value = 'hei'
+    await textarea.trigger('input')
+
+    // During composition, onChange should not be called
+    expect(onChange).not.toHaveBeenCalled()
+
+    // compositionend with final value
+    el.value = '黑'
+    await textarea.trigger('compositionend')
+    await nextTick()
+
+    // Only one call with the final value
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('should trigger onChange during composition when changeOnComposing is true', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount(TextArea, {
+      props: { onChange, changeOnComposing: true },
+    })
+    const textarea = wrapper.find('textarea')
+
+    await textarea.trigger('compositionstart')
+
+    const el = textarea.element as HTMLTextAreaElement
+    el.value = 'h'
+    await textarea.trigger('input')
+    el.value = 'he'
+    await textarea.trigger('input')
+    el.value = 'hei'
+    await textarea.trigger('input')
+
+    // With changeOnComposing=true, onChange fires on every input during composition
+    expect(onChange).toHaveBeenCalledTimes(3)
+
+    el.value = '黑'
+    await textarea.trigger('compositionend')
+    await nextTick()
+
+    // compositionend also triggers onChange
+    expect(onChange).toHaveBeenCalledTimes(4)
+  })
+
+  it('should trigger onChange normally for non-IME input', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount(TextArea, {
+      props: { onChange },
+    })
+    const textarea = wrapper.find('textarea')
+    const el = textarea.element as HTMLTextAreaElement
+
+    // Normal typing (no composition)
+    el.value = 'a'
+    await textarea.trigger('input')
+    el.value = 'ab'
+    await textarea.trigger('input')
+
+    expect(onChange).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/textarea/tests/composition.test.tsx
+++ b/packages/textarea/tests/composition.test.tsx
@@ -63,6 +63,34 @@ describe('textarea IME composition guard', () => {
     expect(onChange).toHaveBeenCalledTimes(3)
   })
 
+  it('should dedup Firefox compositionend→input sequence (default mode)', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount(TextArea, {
+      props: { onChange },
+    })
+    const textarea = wrapper.find('textarea')
+    const el = textarea.element as HTMLTextAreaElement
+
+    await textarea.trigger('compositionstart')
+    el.value = 'h'
+    await textarea.trigger('input')
+    el.value = 'hei'
+    await textarea.trigger('input')
+
+    expect(onChange).not.toHaveBeenCalled()
+
+    // Firefox: compositionend first
+    el.value = '黑'
+    await textarea.trigger('compositionend')
+    await nextTick()
+    expect(onChange).toHaveBeenCalledTimes(1)
+
+    // Firefox: then input with same value — should be deduped
+    await textarea.trigger('input')
+    await nextTick()
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
   it('should trigger onChange normally for non-IME input', async () => {
     const onChange = vi.fn()
     const wrapper = mount(TextArea, {

--- a/packages/textarea/vitest.config.ts
+++ b/packages/textarea/vitest.config.ts
@@ -4,6 +4,8 @@ import configShared from '../../vitest.config'
 export default mergeConfig(
   configShared,
   defineProject({
-
+    test: {
+      environment: 'jsdom',
+    },
   }),
 )


### PR DESCRIPTION
## Summary

Fix IME composition intermediate value leaking in `@v-c/input` and `@v-c/textarea`.

During IME composition (e.g. typing Chinese), `onChange` was firing with intermediate pinyin values (`"h"`, `"he"`, `"hei"`) before the user selects a character. This is a bug — antdv-next is the only Vue 3 component library that leaks these intermediate values (Element Plus, Naive UI, Ant Design Vue 4 all suppress them).

## Changes

- Add `compositionRef` guard at `triggerChange` entry — suppresses `onChange` during composition by default
- New `changeOnComposing` prop (default `false`) — opt-in to React-style behavior for edge cases like real-time pinyin search
- Dedup Firefox's `compositionend → input` event sequence (Firefox fires input AFTER compositionend, unlike Chrome)
- Dedup composition cancel via Esc (no onChange when value hasn't changed)
- Protect `exceedFormatter` from running during active composition (prevents IME candidate corruption)
- Remove unused `ChangeEventInfo` type
- Add jsdom test environment config for both packages
- Add 9 composition guard tests covering default mode, opt-in mode, Firefox dedup, and exceedFormatter protection

## Behavior

| Scenario | Before | After (default) | After (changeOnComposing=true) |
|----------|--------|-----------------|-------------------------------|
| Type "黑" (hei) | 4× onChange: h, he, hei, 黑 | 1× onChange: 黑 | 4× onChange: h, he, hei, 黑 |
| Type then Esc cancel | onChange with intermediate values | 0× onChange | 3× onChange: h, he, hei |
| English input | unchanged | unchanged | unchanged |

## Testing

- [x] 9 unit tests pass (input: 5, textarea: 4)
- [x] Chrome manual: default mode, opt-in mode, Esc cancel, delete, consecutive Chinese
- [x] Firefox manual: default mode (1× not 2×), Esc cancel (0×), delete

## Related

- Closes antdv-next/antdv-next#368
- Discussion: antdv-next/antdv-next#369