### PR TITLE
fix: improve Claude workflow for fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,9 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip fork PRs — OIDC tokens are unavailable for security reasons.
+    # Use @claude in comments to manually trigger review on fork PRs.
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:
@@ -29,7 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Summary

- **Skip auto review on fork PRs**: Added `if` condition to `claude-code-review.yml` to skip fork PRs (OIDC tokens are unavailable for security reasons). Fork PRs can still be reviewed manually via `@claude` in comments.
- **Full clone for fork PR support**: Changed `fetch-depth: 1` → `fetch-depth: 0` in both workflows to ensure full git history is available, improving compatibility with cross-repository PRs.

## Changes

| File | Change |
|------|--------|
| `claude-code-review.yml` | Add fork PR skip condition + `fetch-depth: 0` |
| `claude.yml` | `fetch-depth: 0` for fork PR checkout support |