### PR TITLE
fix(Image): Fixed an issue where the alt attribute of the Image component was not set on the img and preview img elements

### DIFF
--- a/packages/image/docs/basic.tsx
+++ b/packages/image/docs/basic.tsx
@@ -12,6 +12,7 @@ export default defineComponent(() => {
         onClick={() => {
           console.log('click')
         }}
+        alt="basic"
         preview={{
           icons: defaultIcons,
           onOpenChange: (open) => {

--- a/packages/image/src/Image.tsx
+++ b/packages/image/src/Image.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties } from 'vue'
 import type { TransformType } from './hooks/useImageTransform'
 import type { ImageElementProps } from './interface'
 import type { InternalPreviewConfig, PreviewSemanticName, ToolbarRenderInfoType } from './Preview'
-import { clsx } from '@v-c/util'
+import { clsx, omit } from '@v-c/util'
 import useMergedState from '@v-c/util/dist/hooks/useMergedState'
 import pickAttrs from '@v-c/util/dist/pickAttrs'
 import { getAttrStyleAndClass, getStylePxValue } from '@v-c/util/dist/props-util'
@@ -145,8 +145,11 @@ const Image = defineComponent<ImageProps>(
     const imgCommonProps = computed(() => {
       const obj: ImageElementProps = {} as any
       COMMON_PROPS.forEach((prop) => {
-        if ((props as any)[prop] !== undefined) {
-          (obj as any)[prop] = (props as any)[prop]
+        const fromProps = (props as any)[prop]
+        const fromAttrs = (attrs as any)[prop]
+        const val = fromProps !== undefined ? fromProps : fromAttrs
+        if (val !== undefined) {
+          (obj as any)[prop] = val
         }
       })
       return obj
@@ -218,6 +221,7 @@ const Image = defineComponent<ImageProps>(
     return () => {
       const { width, height } = props
       const { className, style: attrStyle, restAttrs } = getAttrStyleAndClass(attrs)
+      const rootAttrs = pickAttrs(omit(restAttrs, COMMON_PROPS), false)
 
       const coverPlacement
         = typeof cover.value === 'object' && cover.value && (cover.value as any).placement
@@ -287,12 +291,12 @@ const Image = defineComponent<ImageProps>(
       return (
         <>
           <div
-            {...pickAttrs(restAttrs, false)}
+            {...rootAttrs}
             class={rootCls}
             onClick={canPreview.value ? onPreview : onInternalClick}
             role={canPreview.value ? 'button' : restAttrs.role}
             tabindex={canPreview.value && restAttrs.tabIndex == null ? 0 : restAttrs.tabIndex}
-            aria-label={canPreview.value ? restAttrs['aria-label'] ?? restAttrs.alt : restAttrs['aria-label']}
+            aria-label={canPreview.value ? restAttrs['aria-label'] ?? imgCommonProps.value.alt : restAttrs['aria-label']}
             onKeydown={onPreviewKeyDown}
             style={rootStyle}
           >
@@ -337,7 +341,7 @@ const Image = defineComponent<ImageProps>(
               onClose={onPreviewClose}
               mousePosition={mousePosition.value}
               src={src.value}
-              alt={props.alt as any}
+              alt={imgCommonProps.value.alt as any}
               imageInfo={{ width: props.width as any, height: props.height as any }}
               fallback={props.fallback}
               imgCommonProps={imgCommonProps.value as any}

--- a/packages/image/src/Preview/index.tsx
+++ b/packages/image/src/Preview/index.tsx
@@ -370,6 +370,8 @@ const Preview = defineComponent<PreviewProps>(
         maskClosable = true,
       } = props
 
+      const mergedAlt = alt ?? (imgCommonProps as any)?.alt
+
       const bodyStyle: CSSProperties = {
         ...(styles.body ?? {}),
       }
@@ -379,7 +381,7 @@ const Preview = defineComponent<PreviewProps>(
 
       const image: ImgInfo = {
         url: src || '',
-        alt: alt || '',
+        alt: mergedAlt || '',
         ...(imageInfo as any),
       }
 
@@ -394,7 +396,7 @@ const Preview = defineComponent<PreviewProps>(
           width={props.width}
           height={props.height}
           class={`${prefixCls}-img`}
-          alt={alt}
+          alt={mergedAlt}
           onLoad={(srcAndOnload.value as any).onLoad}
           style={{
             transform: `translate3d(${transform.value.x}px, ${transform.value.y}px, 0) scale3d(${transform.value.flipX ? '-' : ''
@@ -460,7 +462,7 @@ const Preview = defineComponent<PreviewProps>(
                   style={mergedRootStyle}
                   role="dialog"
                   aria-modal="true"
-                  aria-label={alt}
+                  aria-label={mergedAlt}
                   tabindex={-1}
                 >
                   {/* Mask */}

--- a/packages/image/tests/basic.test.tsx
+++ b/packages/image/tests/basic.test.tsx
@@ -75,9 +75,22 @@ describe('basic', () => {
     const wrapper = mount(Image, {
       props: {
         src: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
-        fetchPriority: 'high'
-      }
+        fetchPriority: 'high',
+      },
     })
-    expect(wrapper.html()).toContain('fetchpriority="high"');
-  });
+    expect(wrapper.html()).toContain('fetchpriority="high"')
+  })
+
+  it('should put alt on img, not on root wrapper', () => {
+    const wrapper = mount(() => (
+      <Image
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+        alt="desc"
+      />
+    ))
+    const root = wrapper.get('.vc-image')
+    const img = wrapper.get('.vc-image-img')
+    expect(img.attributes('alt')).toBe('desc')
+    expect(root.attributes('alt')).toBeUndefined()
+  })
 })

--- a/packages/image/tests/preview.test.tsx
+++ b/packages/image/tests/preview.test.tsx
@@ -93,4 +93,23 @@ describe('preview', () => {
 
     wrapper.unmount()
   })
+
+  it('should set alt on preview img', async () => {
+    const wrapper = mount(() => (
+      <Image
+        src="src"
+        alt="preview alt"
+        preview={{ open: true, getContainer: false } as any}
+      />
+    ), {
+      attachTo: document.body,
+    })
+
+    await flushPreview()
+
+    const previewImg = document.body.querySelector('.vc-image-preview-img') as HTMLImageElement | null
+    expect(previewImg?.getAttribute('alt')).toBe('preview alt')
+
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> N/A

### 💡 Background and Solution

> Background
> Chinese
>> - 当 Image 组件设置 alt 时，在渲染是 alt 并未设置至 img 标签上，而是设置到外层的 div 中

> English
>> - When the `Image` component sets the `alt` attribute, during rendering, the `alt` is not applied to the `img` tag, but rather to the outer `div`.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the alt attribute of the Image component was not set on the img and preview img elements |
| 🇨🇳 Chinese | 修复 Image 组件 alt 属性未设置到 img 与 preview img 上 |
