### PR TITLE
fix(table): sticky scrollbar width not recalculated after body resize

### DIFF
--- a/packages/table/src/stickyScrollBar.tsx
+++ b/packages/table/src/stickyScrollBar.tsx
@@ -2,7 +2,7 @@ import { clsx } from '@v-c/util'
 import { getDOM } from '@v-c/util/dist/Dom/findDOMNode'
 import getScrollBarSize from '@v-c/util/dist/getScrollBarSize'
 import raf from '@v-c/util/dist/raf'
-import { computed, defineComponent, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, defineComponent, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useInjectTableContext } from './context/TableContext'
 import { useLayoutState } from './hooks/useFrame'
 import { getOffset } from './utils/offsetUtil'
@@ -26,6 +26,7 @@ const StickyScrollBar = defineComponent<StickyScrollBarProps>({
   setup(props, { expose }) {
     const { prefixCls } = useInjectTableContext()
     const scrollBarRef = ref<HTMLDivElement | null>(null)
+
     const [scrollState, setScrollState] = useLayoutState<{ scrollLeft: number, isHiddenScrollBar: boolean }>({
       scrollLeft: 0,
       isHiddenScrollBar: true,
@@ -34,8 +35,14 @@ const StickyScrollBar = defineComponent<StickyScrollBarProps>({
     const isActive = ref(false)
     const rafRef = ref<number | null>(null)
 
-    const bodyScrollWidth = computed(() => props.scrollBodyRef.value?.scrollWidth || 0)
-    const bodyWidth = computed(() => props.scrollBodyRef.value?.clientWidth || 0)
+    const bodyScrollWidth = ref(0)
+    const bodyWidth = ref(0)
+    const syncBodySize = () => {
+      const bodyNode = props.scrollBodyRef.value
+      bodyScrollWidth.value = bodyNode?.scrollWidth || 0
+      bodyWidth.value = bodyNode?.clientWidth || 0
+    }
+
     const scrollBarWidth = computed(() => {
       const totalWidth = bodyScrollWidth.value
       const clientWidth = bodyWidth.value
@@ -81,6 +88,7 @@ const StickyScrollBar = defineComponent<StickyScrollBarProps>({
     const checkScrollBarVisible = () => {
       raf.cancel(rafRef.value as any)
       rafRef.value = raf(() => {
+        syncBodySize()
         if (!props.scrollBodyRef.value || !props.container) {
           return
         }
@@ -119,7 +127,7 @@ const StickyScrollBar = defineComponent<StickyScrollBarProps>({
     onMounted(() => {
       document.body.addEventListener(MOUSEUP_EVENT, onMouseUp, false)
       document.body.addEventListener(MOUSEMOVE_EVENT, onMouseMove, false)
-      checkScrollBarVisible()
+      nextTick(checkScrollBarVisible)
     })
 
     const removeScrollListeners = ref<(() => void) | null>(null)
@@ -130,6 +138,17 @@ const StickyScrollBar = defineComponent<StickyScrollBarProps>({
       raf.cancel(rafRef.value as any)
       removeScrollListeners.value?.()
     })
+
+    watch(
+      () => props.scrollBodyRef.value,
+      () => {
+        nextTick(checkScrollBarVisible)
+      },
+      {
+        immediate: true,
+        flush: 'post',
+      },
+    )
 
     watch(
       () => [scrollBarWidth.value, isActive.value],

--- a/packages/table/tests/sticky-scrollbar.test.tsx
+++ b/packages/table/tests/sticky-scrollbar.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, nextTick, ref } from 'vue'
+import { TableContextKey } from '../src/context/TableContext'
+import StickyScrollBar from '../src/stickyScrollBar'
+
+function setElementSize(element: HTMLElement, size: Partial<Pick<HTMLElement, 'clientHeight' | 'clientWidth' | 'offsetHeight' | 'scrollWidth'>>) {
+  Object.entries(size).forEach(([key, value]) => {
+    Object.defineProperty(element, key, {
+      configurable: true,
+      value,
+    })
+  })
+}
+
+async function waitForRaf() {
+  await new Promise(resolve => setTimeout(resolve, 20))
+  await new Promise(resolve => setTimeout(resolve, 20))
+  await nextTick()
+}
+
+describe('table sticky scrollbar', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('updates when the table body size changes after mount', async () => {
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => window.setTimeout(callback, 0))
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(handle => window.clearTimeout(handle))
+
+    const scrollBodyRef = ref<HTMLDivElement | null>(null)
+    const container = document.createElement('div')
+    setElementSize(container, { clientHeight: 100 })
+    container.getBoundingClientRect = () => ({ top: 100, left: 0, right: 200, bottom: 200, width: 200, height: 100 } as DOMRect)
+
+    const body = document.createElement('div')
+    setElementSize(body, {
+      clientWidth: 0,
+      scrollWidth: 0,
+      offsetHeight: 300,
+    })
+    body.getBoundingClientRect = () => ({ top: 0, left: 0, right: 200, bottom: 300, width: 200, height: 300 } as DOMRect)
+    document.body.appendChild(container)
+    container.appendChild(body)
+    scrollBodyRef.value = body
+
+    const wrapper = mount(defineComponent({
+      provide: {
+        [TableContextKey as symbol]: { prefixCls: 'vc-table' },
+      },
+      setup() {
+        return () => h(StickyScrollBar, {
+          scrollBodyRef,
+          container,
+          direction: 'ltr',
+          offsetScroll: 0,
+          onScroll: vi.fn(),
+        })
+      },
+    }), { attachTo: document.body })
+
+    await waitForRaf()
+    expect(wrapper.find('.vc-table-sticky-scroll').exists()).toBe(false)
+
+    setElementSize(body, {
+      clientWidth: 200,
+      scrollWidth: 400,
+      offsetHeight: 300,
+    })
+    window.dispatchEvent(new Event('resize'))
+
+    await waitForRaf()
+
+    expect(wrapper.find('.vc-table-sticky-scroll').attributes('style')).toContain('width: 200px')
+    expect(wrapper.find('.vc-table-sticky-scroll-bar').attributes('style')).toContain('width: 100px')
+
+    wrapper.unmount()
+    container.remove()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes sticky scrollbar width calculation error when the table body size changes (e.g., window resize). The root cause was that `bodyScrollWidth` and `bodyWidth` were `computed` values that only evaluated once during initial render and did not update reactively when the DOM element's dimensions changed.

## Changes

- Changed `bodyScrollWidth` and `bodyWidth` from `computed` to `ref`, with a `syncBodySize()` function that reads actual DOM dimensions
- Added `nextTick` wrapper around `checkScrollBarVisible()` in `onMounted` to ensure DOM is ready
- Added a `watch` on `scrollBodyRef.value` to re-check scrollbar visibility when the body ref changes

## Related

Fixes antdv-next/antdv-next#545 — Table sticky 模式下滚动条宽度计算错误