### PR TITLE
fix(switch): prevent event handlers from being spread onto button element

### DIFF
--- a/packages/switch/src/index.tsx
+++ b/packages/switch/src/index.tsx
@@ -10,22 +10,22 @@ export type SwitchChangeEventHandler = (
 ) => void
 export type SwitchClickEventHandler = SwitchChangeEventHandler
 export interface SwitchProps {
-  className?: string
-  prefixCls?: string
-  disabled?: boolean
-  checkedChildren?: VNodeChild | (() => VNodeChild)
-  unCheckedChildren?: VNodeChild | (() => VNodeChild)
-  onChange?: SwitchChangeEventHandler
+  'className'?: string
+  'prefixCls'?: string
+  'disabled'?: boolean
+  'checkedChildren'?: VNodeChild | (() => VNodeChild)
+  'unCheckedChildren'?: VNodeChild | (() => VNodeChild)
+  'onChange'?: SwitchChangeEventHandler
   'onUpdate:checked'?: (value: boolean) => void
-  onKeyDown?: KeyboardEventHandler
-  onClick?: SwitchClickEventHandler
-  tabIndex?: number
-  checked?: boolean
-  defaultChecked?: boolean
-  loadingIcon?: VNodeChild | (() => VNodeChild)
-  title?: string
-  styles?: { content?: CSSProperties }
-  classNames?: { content?: string }
+  'onKeyDown'?: KeyboardEventHandler
+  'onClick'?: SwitchClickEventHandler
+  'tabIndex'?: number
+  'checked'?: boolean
+  'defaultChecked'?: boolean
+  'loadingIcon'?: VNodeChild | (() => VNodeChild)
+  'title'?: string
+  'styles'?: { content?: CSSProperties }
+  'classNames'?: { content?: string }
 }
 
 const defaults = {
@@ -61,7 +61,8 @@ const Switch = defineComponent<SwitchProps>(
     function onInternalKeyDown(e: KeyboardEvent) {
       if (e.which === KeyCode.LEFT) {
         triggerChange(false, e)
-      } else if (e.which === KeyCode.RIGHT) {
+      }
+      else if (e.which === KeyCode.RIGHT) {
         triggerChange(true, e)
       }
       props?.onKeyDown?.(e)
@@ -104,8 +105,8 @@ const Switch = defineComponent<SwitchProps>(
         <button
           {...(restProps as any)}
           {...attrs}
-          type='button'
-          role='switch'
+          type="button"
+          role="switch"
           aria-checked={innerChecked.value}
           disabled={disabled}
           class={switchClassName}

--- a/packages/switch/src/index.tsx
+++ b/packages/switch/src/index.tsx
@@ -10,22 +10,22 @@ export type SwitchChangeEventHandler = (
 ) => void
 export type SwitchClickEventHandler = SwitchChangeEventHandler
 export interface SwitchProps {
-  'className'?: string
-  'prefixCls'?: string
-  'disabled'?: boolean
-  'checkedChildren'?: VNodeChild | (() => VNodeChild)
-  'unCheckedChildren'?: VNodeChild | (() => VNodeChild)
-  'onChange'?: SwitchChangeEventHandler
+  className?: string
+  prefixCls?: string
+  disabled?: boolean
+  checkedChildren?: VNodeChild | (() => VNodeChild)
+  unCheckedChildren?: VNodeChild | (() => VNodeChild)
+  onChange?: SwitchChangeEventHandler
   'onUpdate:checked'?: (value: boolean) => void
-  'onKeyDown'?: KeyboardEventHandler
-  'onClick'?: SwitchClickEventHandler
-  'tabIndex'?: number
-  'checked'?: boolean
-  'defaultChecked'?: boolean
-  'loadingIcon'?: VNodeChild | (() => VNodeChild)
-  'title'?: string
-  'styles'?: { content?: CSSProperties }
-  'classNames'?: { content?: string }
+  onKeyDown?: KeyboardEventHandler
+  onClick?: SwitchClickEventHandler
+  tabIndex?: number
+  checked?: boolean
+  defaultChecked?: boolean
+  loadingIcon?: VNodeChild | (() => VNodeChild)
+  title?: string
+  styles?: { content?: CSSProperties }
+  classNames?: { content?: string }
 }
 
 const defaults = {
@@ -61,8 +61,7 @@ const Switch = defineComponent<SwitchProps>(
     function onInternalKeyDown(e: KeyboardEvent) {
       if (e.which === KeyCode.LEFT) {
         triggerChange(false, e)
-      }
-      else if (e.which === KeyCode.RIGHT) {
+      } else if (e.which === KeyCode.RIGHT) {
         triggerChange(true, e)
       }
       props?.onKeyDown?.(e)
@@ -87,18 +86,26 @@ const Switch = defineComponent<SwitchProps>(
         unCheckedChildren,
         classNames,
         styles,
+        onChange: _onChange,
+        onClick: _onClick,
+        onKeyDown: _onKeyDown,
+        'onUpdate:checked': _onUpdateChecked,
         ...restProps
       } = props
-      const switchClassName = [prefixCls, className, {
-        [`${prefixCls}-checked`]: innerChecked.value,
-        [`${prefixCls}-disabled`]: disabled,
-      }]
+      const switchClassName = [
+        prefixCls,
+        className,
+        {
+          [`${prefixCls}-checked`]: innerChecked.value,
+          [`${prefixCls}-disabled`]: disabled,
+        },
+      ]
       return (
         <button
-          {...restProps as any}
+          {...(restProps as any)}
           {...attrs}
-          type="button"
-          role="switch"
+          type='button'
+          role='switch'
           aria-checked={innerChecked.value}
           disabled={disabled}
           class={switchClassName}

--- a/packages/switch/tests/index.test.tsx
+++ b/packages/switch/tests/index.test.tsx
@@ -1,0 +1,54 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import Switch from '../src'
+
+describe('switch event handlers', () => {
+  it('invokes onChange / onClick / onUpdate:checked on toggle', async () => {
+    const onChange = vi.fn()
+    const onClick = vi.fn()
+    const onUpdate = vi.fn()
+    const wrapper = mount(() => (
+      <Switch
+        onChange={onChange}
+        onClick={onClick}
+        {...{ 'onUpdate:checked': onUpdate }}
+      />
+    ))
+    await wrapper.find('button').trigger('click')
+    expect(onChange).toHaveBeenCalledWith(true, expect.any(MouseEvent))
+    expect(onClick).toHaveBeenCalledWith(true, expect.any(MouseEvent))
+    expect(onUpdate).toHaveBeenCalledWith(true)
+  })
+
+  it('fires click handlers exactly once per click', async () => {
+    const onClick = vi.fn()
+    const onChange = vi.fn()
+    const onUpdate = vi.fn()
+    const wrapper = mount(() => (
+      <Switch
+        onChange={onChange}
+        onClick={onClick}
+        {...{ 'onUpdate:checked': onUpdate }}
+      />
+    ))
+    await wrapper.find('button').trigger('click')
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not leak event handlers onto the DOM button as attributes', () => {
+    const wrapper = mount(() => (
+      <Switch
+        onChange={() => {}}
+        onClick={() => {}}
+        onKeyDown={() => {}}
+        {...{ 'onUpdate:checked': () => {} }}
+      />
+    ))
+    const btn = wrapper.find('button').element as HTMLElement
+    expect(btn.getAttribute('onChange')).toBeNull()
+    expect(btn.getAttribute('onUpdate:checked')).toBeNull()
+    expect(btn.getAttribute('onKeyDown')).toBeNull()
+  })
+})

--- a/packages/switch/vitest.config.ts
+++ b/packages/switch/vitest.config.ts
@@ -4,6 +4,8 @@ import configShared from '../../vitest.config'
 export default mergeConfig(
   configShared,
   defineProject({
-
+    test: {
+      environment: 'jsdom',
+    },
   }),
 )


### PR DESCRIPTION
## Summary
- Destructure `onChange`, `onClick`, `onKeyDown`, and `onUpdate:checked` out of `restProps` so they aren't spread onto the native `<button>` element

