### PR TITLE
sync: align with upstream rc fixes & features (trigger/input/menu/virtual-list)

### DIFF
--- a/.sync-upstream.json
+++ b/.sync-upstream.json
@@ -16,11 +16,11 @@
           "description": "@rc-component/async-validator -> @v-c/async-validator"
         }
       ],
-      "last_synced_commit": "b2b321766055ee9a1257f629a434906625a14557",
-      "last_synced_commit_short": "b2b32176",
-      "last_synced_at": "2026-04-14T13:45:25Z",
+      "last_synced_commit": "ed700385d5fdf2094c6dcad1588b3edf03ea28ee",
+      "last_synced_commit_short": "ed700385d5",
+      "last_synced_at": "2026-06-02T09:19:58Z",
       "last_synced_tag": "v5.1.0",
-      "sync_count": 1
+      "sync_count": 2
     },
     {
       "name": "@rc-component/cascader",
@@ -33,11 +33,11 @@
           "description": "@rc-component/cascader -> @v-c/cascader"
         }
       ],
-      "last_synced_commit": "261350564c311a296a0342f24f2eb3b4764ffeaa",
-      "last_synced_commit_short": "26135056",
-      "last_synced_at": "2026-04-14T13:45:25Z",
+      "last_synced_commit": "950b623248710cf238f7610d947a3e9ab8eda905",
+      "last_synced_commit_short": "950b623248",
+      "last_synced_at": "2026-06-02T09:19:58Z",
       "last_synced_tag": "@rc-component/cascader@1.15.0",
-      "sync_count": 1
+      "sync_count": 2
     },
     {
       "name": "@rc-component/checkbox",
@@ -186,11 +186,11 @@
           "description": "@rc-component/input -> @v-c/input"
         }
       ],
-      "last_synced_commit": "0215da50f7182c619b5a7ab206a3ef82f061fafe",
-      "last_synced_commit_short": "0215da50",
-      "last_synced_at": "2026-05-16T03:02:39Z",
-      "last_synced_tag": "@rc-component/input@1.3.0",
-      "sync_count": 2
+      "last_synced_commit": "cd850acf8b6ef22c2a941dc983b0ba3e23acc702",
+      "last_synced_commit_short": "cd850acf8b",
+      "last_synced_at": "2026-06-02T09:19:58Z",
+      "last_synced_tag": "@rc-component/input@1.3.1",
+      "sync_count": 3
     },
     {
       "name": "@rc-component/input-number",
@@ -220,11 +220,11 @@
           "description": "@rc-component/mentions -> @v-c/mentions"
         }
       ],
-      "last_synced_commit": "4e54fe144c2d464470fb55eb5b4a2f0323ff368f",
-      "last_synced_commit_short": "4e54fe14",
-      "last_synced_at": "2026-04-14T13:45:25Z",
+      "last_synced_commit": "8a718cb96d253921f8c819ff3c95fb453ef4f0d0",
+      "last_synced_commit_short": "8a718cb96d",
+      "last_synced_at": "2026-06-02T09:19:58Z",
       "last_synced_tag": "@rc-component/mentions@1.9.0",
-      "sync_count": 1
+      "sync_count": 2
     },
     {
       "name": "@rc-component/menu",
@@ -237,11 +237,11 @@
           "description": "@rc-component/menu -> @v-c/menu"
         }
       ],
-      "last_synced_commit": "038c4b30e9a1482f124b71164a06467fa27df468",
-      "last_synced_commit_short": "038c4b30",
-      "last_synced_at": "2026-04-14T13:45:25Z",
-      "last_synced_tag": "@rc-component/menu@1.3.0",
-      "sync_count": 1
+      "last_synced_commit": "e9643ea40bf2a72e225f8998a0f2cab163ac4329",
+      "last_synced_commit_short": "e9643ea40b",
+      "last_synced_at": "2026-06-02T09:19:58Z",
+      "last_synced_tag": "@rc-component/menu@1.4.0",
+      "sync_count": 2
     },
     {
       "name": "@rc-component/mini-decimal",
@@ -254,11 +254,11 @@
           "description": "@rc-component/mini-decimal -> @v-c/mini-decimal"
         }
       ],
-      "last_synced_commit": "2f43401c8809ebe6190a947839cd6d054ce5c739",
-      "last_synced_commit_short": "2f43401c",
-      "last_synced_at": "2026-05-16T08:22:17Z",
+      "last_synced_commit": "d9c73892ca0ec3e66f8fa761c8d2aea2ccb353d1",
+      "last_synced_commit_short": "d9c73892ca",
+      "last_synced_at": "2026-06-02T09:19:58Z",
       "last_synced_tag": "v1.1.0",
-      "sync_count": 1
+      "sync_count": 2
     },
     {
       "name": "@rc-component/mutate-observer",
@@ -322,11 +322,11 @@
           "description": "@rc-component/pagination -> @v-c/pagination"
         }
       ],
-      "last_synced_commit": "a85aa10168fcc137c52930b0d429b0c88587f3ee",
-      "last_synced_commit_short": "a85aa101",
-      "last_synced_at": "2026-05-16T08:22:17Z",
+      "last_synced_commit": "65040ce697f79d4bf4153af526f59a2f9d4a5bd2",
+      "last_synced_commit_short": "65040ce697",
+      "last_synced_at": "2026-06-02T09:19:58Z",
       "last_synced_tag": "@rc-component/pagination@1.2.0",
-      "sync_count": 1
+      "sync_count": 2
     },
     {
       "name": "@rc-component/picker",
@@ -356,11 +356,11 @@
           "description": "@rc-component/portal -> @v-c/portal"
         }
       ],
-      "last_synced_commit": "8b5c5fb1efd1c7c890c6b723d66f2d8602c7bb11",
-      "last_synced_commit_short": "8b5c5fb1",
-      "last_synced_at": "2026-05-16T08:16:37Z",
+      "last_synced_commit": "8a2782c3791bed8318b78997dedc6204d78ef6a6",
+      "last_synced_commit_short": "8a2782c379",
+      "last_synced_at": "2026-06-02T09:19:58Z",
       "last_synced_tag": "@rc-component/portal@2.2.0",
-      "sync_count": 2
+      "sync_count": 3
     },
     {
       "name": "@rc-component/progress",
@@ -390,11 +390,11 @@
           "description": "@rc-component/qrcode -> @v-c/qrcode"
         }
       ],
-      "last_synced_commit": "56cabfb63781a567915ceaa641236c919892c896",
-      "last_synced_commit_short": "56cabfb6",
-      "last_synced_at": "2026-04-14T13:45:25Z",
+      "last_synced_commit": "a79d3d61a63b62a5c4e2d3492917a9fa494a0c4d",
+      "last_synced_commit_short": "a79d3d61a6",
+      "last_synced_at": "2026-06-02T09:19:58Z",
       "last_synced_tag": "@rc-component/qrcode@1.1.1",
-      "sync_count": 1
+      "sync_count": 2
     },
     {
       "name": "@rc-component/rate",
@@ -458,11 +458,11 @@
           "description": "@rc-component/select -> @v-c/select"
         }
       ],
-      "last_synced_commit": "6fe40e33ebe6440d11612f3cd0d45a2c63f842f4",
-      "last_synced_commit_short": "6fe40e33",
-      "last_synced_at": "2026-05-16T03:02:39Z",
-      "last_synced_tag": "@rc-component/select@1.7.0",
-      "sync_count": 2
+      "last_synced_commit": "7876c6c2e456ef44e3bad63bf7609a0d4b1f2bc1",
+      "last_synced_commit_short": "7876c6c2e4",
+      "last_synced_at": "2026-06-02T09:19:58Z",
+      "last_synced_tag": "@rc-component/select@1.7.1",
+      "sync_count": 3
     },
     {
       "name": "@ant-design/react-slick",
@@ -543,11 +543,11 @@
           "description": "@rc-component/table -> @v-c/table"
         }
       ],
-      "last_synced_commit": "d5b5bb1a7c1587281482808203e456959fdae7d7",
-      "last_synced_commit_short": "d5b5bb1a",
-      "last_synced_at": "2026-05-16T03:02:39Z",
-      "last_synced_tag": "@rc-component/table@1.10.0",
-      "sync_count": 2
+      "last_synced_commit": "b611eb2623f4891a4ff4dc7a27a1305425196fb8",
+      "last_synced_commit_short": "b611eb2623",
+      "last_synced_at": "2026-06-02T09:19:58Z",
+      "last_synced_tag": "@rc-component/table@1.10.2",
+      "sync_count": 3
     },
     {
       "name": "@rc-component/tabs",
@@ -560,11 +560,11 @@
           "description": "@rc-component/tabs -> @v-c/tabs"
         }
       ],
-      "last_synced_commit": "3732bf57df149c67f4ac394e4b0a302d855d15ed",
-      "last_synced_commit_short": "3732bf57",
-      "last_synced_at": "2026-04-14T13:45:25Z",
+      "last_synced_commit": "926f67ec60cfa5d5672e03ec22ecf7e87f8aa806",
+      "last_synced_commit_short": "926f67ec60",
+      "last_synced_at": "2026-06-02T09:19:58Z",
       "last_synced_tag": "@rc-component/tabs@1.9.0",
-      "sync_count": 1
+      "sync_count": 2
     },
     {
       "name": "@rc-component/textarea",
@@ -628,11 +628,11 @@
           "description": "@rc-component/tree -> @v-c/tree"
         }
       ],
-      "last_synced_commit": "1f049b29e831b13159cf78233a570d4628b88613",
-      "last_synced_commit_short": "1f049b29",
-      "last_synced_at": "2026-05-16T08:16:37Z",
-      "last_synced_tag": "@rc-component/tree@1.3.1",
-      "sync_count": 2
+      "last_synced_commit": "468177253aaf4188d6c9e6063bd62f008dbae2aa",
+      "last_synced_commit_short": "468177253a",
+      "last_synced_at": "2026-06-02T09:19:58Z",
+      "last_synced_tag": "@rc-component/tree@1.3.2",
+      "sync_count": 3
     },
     {
       "name": "@rc-component/tree-select",
@@ -662,11 +662,11 @@
           "description": "@rc-component/trigger -> @v-c/trigger"
         }
       ],
-      "last_synced_commit": "59b659da4aad1f073d7783b1bfd907ee0ccbed65",
-      "last_synced_commit_short": "59b659da",
-      "last_synced_at": "2026-04-14T13:45:25Z",
-      "last_synced_tag": "@rc-component/trigger@3.9.0",
-      "sync_count": 1
+      "last_synced_commit": "220358ddee26e8b00e97a6b06dadd5612e53066b",
+      "last_synced_commit_short": "220358ddee",
+      "last_synced_at": "2026-06-02T09:19:58Z",
+      "last_synced_tag": "@rc-component/trigger@3.9.1",
+      "sync_count": 2
     },
     {
       "name": "@rc-component/upload",
@@ -679,11 +679,11 @@
           "description": "@rc-component/upload -> @v-c/upload"
         }
       ],
-      "last_synced_commit": "799024c144e82b32ba3c57ecccbf74b73fcf0021",
-      "last_synced_commit_short": "799024c1",
-      "last_synced_at": "2026-05-16T08:16:37Z",
-      "last_synced_tag": "@rc-component/upload@1.1.0",
-      "sync_count": 2
+      "last_synced_commit": "d53036dbfab8b2efca4942a7f8c76d15fbdcafc5",
+      "last_synced_commit_short": "d53036dbfa",
+      "last_synced_at": "2026-06-02T09:19:58Z",
+      "last_synced_tag": "@rc-component/upload@1.1.1",
+      "sync_count": 3
     },
     {
       "name": "@rc-component/util",
@@ -696,11 +696,11 @@
           "description": "@rc-component/util -> @v-c/util"
         }
       ],
-      "last_synced_commit": "6dba3e18057cc33cd3e2347de0f8e07c186d0b43",
-      "last_synced_commit_short": "6dba3e18",
-      "last_synced_at": "2026-05-16T08:21:19Z",
+      "last_synced_commit": "b7731c336e96580dd9af44b4e5c98161c77950f9",
+      "last_synced_commit_short": "b7731c336e",
+      "last_synced_at": "2026-06-02T09:19:58Z",
       "last_synced_tag": "@rc-component/util@1.10.0",
-      "sync_count": 2
+      "sync_count": 3
     },
     {
       "name": "@rc-component/virtual-list",
@@ -713,11 +713,11 @@
           "description": "@rc-component/virtual-list -> @v-c/virtual-list"
         }
       ],
-      "last_synced_commit": "402e156e4a7c9152e3f6db98572afff8acd28b66",
-      "last_synced_commit_short": "402e156e",
-      "last_synced_at": "2026-04-14T13:45:25Z",
-      "last_synced_tag": "@rc-component/virtual-list@1.0.1",
-      "sync_count": 1
+      "last_synced_commit": "2e032d44fac868a86b1e3eabc6c16f3ef2545868",
+      "last_synced_commit_short": "2e032d44fa",
+      "last_synced_at": "2026-06-02T09:19:58Z",
+      "last_synced_tag": "@rc-component/virtual-list@1.2.0",
+      "sync_count": 2
     }
   ]
 }

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@v-c/input",
   "type": "module",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "publishConfig": {
     "access": "public"

--- a/packages/input/src/utils/commonUtils.ts
+++ b/packages/input/src/utils/commonUtils.ts
@@ -20,12 +20,10 @@ function createPatchedTarget<
   return patched
 }
 
-function cloneEvent<
+function buildSafeEvent<
   EventType extends Event,
   Element extends HTMLInputElement | HTMLTextAreaElement,
->(event: EventType, target: Element, value: any): EventType {
-  const patchedTarget = createPatchedTarget(target, value)
-
+>(event: EventType, target: Element): EventType {
   const safeEvent: any = {
     type: (event as any)?.type,
     timeStamp: (event as any)?.timeStamp,
@@ -33,8 +31,8 @@ function cloneEvent<
     cancelable: (event as any)?.cancelable,
     composed: (event as any)?.composed,
 
-    target: patchedTarget,
-    currentTarget: patchedTarget,
+    target,
+    currentTarget: target,
 
     preventDefault: (event as any)?.preventDefault
       ? (event as any).preventDefault.bind(event)
@@ -50,6 +48,24 @@ function cloneEvent<
   }
 
   return safeEvent as EventType
+}
+
+// 需要修改 value 时，克隆一个带有新 value 的 target（detached），避免污染真实节点
+function cloneEvent<
+  EventType extends Event,
+  Element extends HTMLInputElement | HTMLTextAreaElement,
+>(event: EventType, target: Element, value: any): EventType {
+  const patchedTarget = createPatchedTarget(target, value)
+  return buildSafeEvent(event, patchedTarget)
+}
+
+// value 无需修改时，保持真实 target 挂载，避免使用 detached clone
+// https://github.com/react-component/input/pull/175
+function cloneEventWithTarget<
+  EventType extends Event,
+  Element extends HTMLInputElement | HTMLTextAreaElement,
+>(event: EventType, target: Element): EventType {
+  return buildSafeEvent(event, target)
 }
 
 export function hasAddon(props: BaseInputProps | InputProps) {
@@ -75,7 +91,12 @@ export function resolveOnChange<E extends HTMLInputElement | HTMLTextAreaElement
   }
 
   if (target.type !== 'file' && targetValue !== undefined) {
-    onChange(cloneEvent(e as any, target, targetValue))
+    if (target.value !== targetValue) {
+      onChange(cloneEvent(e as any, target, targetValue))
+    }
+    else {
+      onChange(cloneEventWithTarget(e as any, target))
+    }
     return
   }
 

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@v-c/menu",
   "type": "module",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "menu ui component for vue",
   "exports": {
     ".": {

--- a/packages/menu/src/MenuItem.tsx
+++ b/packages/menu/src/MenuItem.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'vue'
-import type { MenuItemType } from './interface.ts'
+import type { ItemData, MenuItemType } from './interface.ts'
 import Overflow from '@v-c/overflow'
 import { clsx, warning } from '@v-c/util'
 import KeyCode from '@v-c/util/dist/KeyCode'
@@ -24,6 +24,9 @@ export interface MenuItemProps extends Omit<MenuItemType, 'label' | 'key'> {
 
   /** @deprecated No place to use this. Should remove */
   attribute?: Record<string, string>
+
+  /** @private Origin item config from items prop */
+  itemData?: ItemData
 
   onKeyDown?: (e: KeyboardEvent) => void
   onFocus?: (e: FocusEvent) => void
@@ -91,11 +94,20 @@ const InternalMenuItem = defineComponent<MenuItemProps>(
     }
     // ============================= Info =============================
     const getEventInfo = (e: MouseEvent | KeyboardEvent) => {
+      // If itemData exists (items mode), use it; otherwise build from props (children mode)
+      const itemData: ItemData = props.itemData || {
+        key: eventKey.value || '',
+        label: slots?.default?.(),
+        itemIcon: props.itemIcon,
+        extra: props.extra,
+      }
+
       return {
         key: eventKey.value,
         keyPath: connectedKeys.value,
         item: legacyMenuItemRef.value,
         domEvent: e,
+        itemData,
       }
     }
 

--- a/packages/menu/src/interface.ts
+++ b/packages/menu/src/interface.ts
@@ -64,6 +64,14 @@ export interface MenuItemType extends ItemSharedProps {
   onClick?: MenuClickEventHandler
 }
 
+/** Info item type passed to onSelect/onClick callbacks, excluding event handlers */
+export interface ItemData {
+  label?: VueNode
+  itemIcon?: RenderIconType
+  extra?: VueNode
+  key: Key
+}
+
 export interface MenuItemGroupType extends ItemSharedProps {
   type: 'group'
 
@@ -100,6 +108,7 @@ export interface MenuInfo {
   /** @deprecated This will not support in future. You should avoid to use this */
   item: VueNode
   domEvent: MouseEvent
+  itemData: ItemData
 }
 
 export interface MenuTitleInfo {

--- a/packages/menu/src/utils/nodeUtil.tsx
+++ b/packages/menu/src/utils/nodeUtil.tsx
@@ -84,7 +84,13 @@ function convertItemsToNodes(
 
         const hasExtra = !!extra || extra === 0
         return (
-          <MergedMenuItem key={mergedKey} {...restProps} extra={extra} icon={icon}>
+          <MergedMenuItem
+            key={mergedKey}
+            {...restProps}
+            extra={extra}
+            icon={icon}
+            itemData={{ label, key: mergedKey, itemIcon: restProps?.itemIcon, extra }}
+          >
             {hasExtra
               ? <span class={`${prefixCls}-item-label`}>{label}</span>
               : label}

--- a/packages/menu/src/utils/nodeUtil.tsx
+++ b/packages/menu/src/utils/nodeUtil.tsx
@@ -89,7 +89,7 @@ function convertItemsToNodes(
             {...restProps}
             extra={extra}
             icon={icon}
-            itemData={{ label, key: mergedKey, itemIcon: restProps?.itemIcon, extra }}
+            itemData={{ label, key: mergedKey, itemIcon: icon ?? restProps?.itemIcon, extra }}
           >
             {hasExtra
               ? <span class={`${prefixCls}-item-label`}>{label}</span>

--- a/packages/menu/tests/itemData.spec.tsx
+++ b/packages/menu/tests/itemData.spec.tsx
@@ -1,0 +1,55 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { h, nextTick } from 'vue'
+import Menu, { Item as MenuItem } from '../src'
+
+async function flushMenu() {
+  await Promise.resolve()
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+describe('menu onClick/onSelect itemData payload', () => {
+  it('reports the resolved icon in itemData for items mode', async () => {
+    const onClick = vi.fn()
+    const iconNode = h('span', { class: 'leading-icon' })
+    const wrapper = mount(Menu, {
+      props: {
+        onClick,
+        items: [
+          { key: '1', label: 'Option 1', icon: iconNode, extra: 'X' },
+        ],
+      },
+    })
+
+    await flushMenu()
+    await wrapper.find('.vc-menu-item').trigger('click')
+
+    expect(onClick).toHaveBeenCalled()
+    const { itemData } = onClick.mock.calls[0][0]
+    expect(itemData.key).toBe('1')
+    expect(itemData.label).toBe('Option 1')
+    expect(itemData.extra).toBe('X')
+    // Regression: itemData must report the displayed icon, not undefined
+    expect(itemData.itemIcon).toBe(iconNode)
+  })
+
+  it('builds itemData from props in children mode', async () => {
+    const onClick = vi.fn()
+    const wrapper = mount(Menu, {
+      props: { onClick },
+      slots: {
+        default: () => h(MenuItem, { key: 'a', extra: 'Y' }, { default: () => 'Child' }),
+      },
+    })
+
+    await flushMenu()
+    await wrapper.find('.vc-menu-item').trigger('click')
+
+    expect(onClick).toHaveBeenCalled()
+    const { itemData } = onClick.mock.calls[0][0]
+    expect(itemData.key).toBe('a')
+    expect(itemData.extra).toBe('Y')
+  })
+})

--- a/packages/trigger/package.json
+++ b/packages/trigger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@v-c/trigger",
   "type": "module",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "",
   "publishConfig": {
     "access": "public"

--- a/packages/trigger/src/hooks/useAlign.ts
+++ b/packages/trigger/src/hooks/useAlign.ts
@@ -180,6 +180,8 @@ export default function useAlign(
       const originRight = popupElement.style.right
       const originBottom = popupElement.style.bottom
       const originOverflow = popupElement.style.overflow
+      const originOverflowX = popupElement.style.overflowX
+      const originOverflowY = popupElement.style.overflowY
       // Placement
       const placementInfo: AlignType = {
         ...builtinPlacements.value[placement.value],
@@ -291,6 +293,8 @@ export default function useAlign(
       popupElement.style.right = originRight
       popupElement.style.bottom = originBottom
       popupElement.style.overflow = originOverflow
+      popupElement.style.overflowX = originOverflowX
+      popupElement.style.overflowY = originOverflowY
 
       popupElement.parentElement?.removeChild(placeholderElement)
 

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@v-c/virtual-list",
   "type": "module",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Vue Virtual List Component",
   "author": "",
   "license": "MIT",

--- a/packages/virtual-list/src/List.tsx
+++ b/packages/virtual-list/src/List.tsx
@@ -2,6 +2,7 @@ import type { Key } from '@v-c/util/dist/type'
 
 import type { CSSProperties, PropType, VNode } from 'vue'
 import type { InnerProps } from './Filler'
+import type { ScrollOffset, ScrollOffsetInfo } from './hooks/useScrollTo'
 import type { ExtraRenderInfo } from './interface'
 import type { ScrollBarDirectionType, ScrollBarRef } from './ScrollBar'
 import ResizeObserver from '@v-c/resize-observer'
@@ -48,10 +49,12 @@ export interface ScrollTarget {
   index?: number
   key?: Key
   align?: 'top' | 'bottom' | 'auto'
-  offset?: number
+  offset?: ScrollOffset
 }
 
 export type ScrollConfig = ScrollTarget | ScrollPos
+
+export type { ScrollOffset, ScrollOffsetInfo }
 
 export interface ListProps {
   prefixCls?: string
@@ -537,12 +540,15 @@ export default defineComponent({
     }
 
     // ================================= Ref ==================================
+    const getSize = useGetSize(mergedData, getKey, heights, itemHeight as any)
+
     const [scrollTo, getTotalHeight] = useScrollTo(
       componentRef as any,
       mergedData,
       heights,
       itemHeight as any,
       getKey,
+      getSize,
       () => collectHeight(true),
       (newTop: number) => {
         // Use getTotalHeight to get more accurate max scroll height
@@ -590,8 +596,6 @@ export default defineComponent({
         flush: 'post',
       },
     )
-
-    const getSize = useGetSize(mergedData, getKey, heights, itemHeight as any)
 
     const listChildren = useChildren(
       mergedData,

--- a/packages/virtual-list/src/hooks/useScrollTo.tsx
+++ b/packages/virtual-list/src/hooks/useScrollTo.tsx
@@ -1,6 +1,6 @@
 import type { Key } from '@v-c/util/dist/type'
 import type { Ref } from 'vue'
-import type { GetKey } from '../interface'
+import type { GetKey, GetSize } from '../interface'
 import type CacheMap from '../utils/CacheMap'
 import { warning } from '@v-c/util'
 import { shallowRef, watch } from 'vue'
@@ -14,14 +14,30 @@ export interface ScrollPos {
   top?: number
 }
 
+export interface ScrollOffsetInfo {
+  /**
+   * Get item size range by key.
+   * 通过 key 获取元素在虚拟列表中的尺寸范围。
+   */
+  getSize: GetSize
+}
+
+export type ScrollOffset = number | ((info: ScrollOffsetInfo) => number)
+
 export type ScrollTarget = {
   index: number
   align?: ScrollAlign
-  offset?: number
+  offset?: ScrollOffset
 } | {
   key: Key
   align?: ScrollAlign
-  offset?: number
+  offset?: ScrollOffset
+}
+
+function getOffset(rawOffset: ScrollOffset, info: ScrollOffsetInfo) {
+  const resolvedOffset = typeof rawOffset === 'function' ? rawOffset(info) : rawOffset
+
+  return Number.isFinite(resolvedOffset) ? resolvedOffset : 0
 }
 
 export default function useScrollTo(
@@ -30,6 +46,7 @@ export default function useScrollTo(
   heights: CacheMap,
   itemHeight: Ref<number>,
   getKey: GetKey<any>,
+  getSize: GetSize,
   collectHeight: () => void,
   syncScrollTop: (newTop: number) => void,
   triggerFlash: () => void,
@@ -37,7 +54,7 @@ export default function useScrollTo(
   const syncState = shallowRef<{
     times: number
     index: number
-    offset: number
+    offset: ScrollOffset
     originAlign: ScrollAlign
     targetAlign?: 'top' | 'bottom'
     lastTop?: number
@@ -68,7 +85,8 @@ export default function useScrollTo(
 
         collectHeight()
 
-        const { targetAlign, originAlign, index, offset } = syncState.value
+        const { targetAlign, originAlign, index, offset: rawOffset } = syncState.value
+        const offset = getOffset(rawOffset, { getSize })
 
         const height = containerRef.value.clientHeight
         let needCollectHeight = false
@@ -191,12 +209,12 @@ export default function useScrollTo(
         index = data.value.findIndex(item => getKey(item) === arg.key)
       }
 
-      const { offset = 0 } = arg
+      const { offset: rawOffset = 0 } = arg
 
       syncState.value = {
         times: 0,
         index,
-        offset,
+        offset: rawOffset,
         originAlign: align!,
       }
     }

--- a/packages/virtual-list/src/index.ts
+++ b/packages/virtual-list/src/index.ts
@@ -1,5 +1,5 @@
 import List from './List'
 
-export type { ListProps, ListRef, ScrollConfig, ScrollInfo, ScrollTo } from './List'
+export type { ListProps, ListRef, ScrollConfig, ScrollInfo, ScrollOffset, ScrollOffsetInfo, ScrollTo } from './List'
 
 export default List


### PR DESCRIPTION
同步 react-component 上游最新 fix/feat 到 `@v-c/*`。

## 改动（按包）

| 类型 | 包 | 上游 PR | 说明 |
|------|-----|---------|------|
| fix | `@v-c/trigger` | [trigger#615](https://github.com/react-component/trigger/pull/615) | force align 时一并保存/恢复 `overflowX`/`overflowY`，避免用户设置丢失 |
| fix | `@v-c/input` | [input#175](https://github.com/react-component/input/pull/175) | value 未变化时保留真实 target，避免 `onChange` 拿到 detached 克隆节点 |
| feat | `@v-c/menu` | [menu#864](https://github.com/react-component/menu/pull/864) | `onSelect`/`onClick` 回调 info 新增 `itemData`（label/itemIcon/extra/key），items & children 模式均支持 |
| feat | `@v-c/virtual-list` | [virtual-list#358](https://github.com/react-component/virtual-list/pull/358) | `scrollTo` 的 `offset` 支持函数 `(info: { getSize }) => number` |

均为向后兼容（两个 fix + 两个非破坏性新增字段/能力）。

## 测试
- 相关包单测全部通过（trigger/input/menu/virtual-list）
- 唯一失败用例 `trigger > ignores popup scale transforms` 经 stash 验证为**改动前即存在的历史失败**，与本次无关
- lint 通过

## 同步基线
`.sync-upstream.json` 已把本轮分析过的 17 个上游 `last_synced_commit` 推进到当前 HEAD（4 个已同步 + 13 个 deep-imports/version-bump 类已审阅跳过），25 个本就最新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
