### PR TITLE
[codex] fix(table): keep empty placeholder fixed while scrolling

### DIFF
--- a/packages/table/src/Body/ExpandedRow.tsx
+++ b/packages/table/src/Body/ExpandedRow.tsx
@@ -61,9 +61,12 @@ const ExpandedRow = defineComponent<ExpandedRowProps>({
       }
       return (
         <Component class={className} style={{ display: expanded ? null : 'none' }}>
-          <Cell component={cellComponent} prefixCls={prefixCls} colSpan={colSpan}>
-            {contentNode}
-          </Cell>
+          <Cell
+            component={cellComponent}
+            prefixCls={prefixCls}
+            colSpan={colSpan}
+            children={contentNode}
+          />
         </Component>
       )
     }

--- a/packages/table/tests/empty-scroll.test.tsx
+++ b/packages/table/tests/empty-scroll.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import { _rs } from '@v-c/resize-observer'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+import Table, { INTERNAL_HOOKS } from '../src'
+
+async function flushResize() {
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+function mockElementWidth(element: HTMLElement, width: number) {
+  Object.defineProperty(element, 'offsetWidth', {
+    configurable: true,
+    get: () => width,
+  })
+  element.getBoundingClientRect = () =>
+    ({
+      width,
+      height: 100,
+      top: 0,
+      left: 0,
+      right: width,
+      bottom: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }) as DOMRect
+}
+
+describe('empty state with horizontal scroll', () => {
+  it('keeps the empty content inside the measured sticky viewport', async () => {
+    const wrapper = mount(Table, {
+      attachTo: document.body,
+      props: {
+        columns: [
+          { title: 'Name', dataIndex: 'name', width: 200, fixed: 'start' },
+          { title: 'Column 1', dataIndex: 'column1', width: 200 },
+          { title: 'Column 2', dataIndex: 'column2', width: 200 },
+          { title: 'Action', dataIndex: 'action', width: 200, fixed: 'end' },
+        ],
+        data: [],
+        emptyText: 'No data',
+        scroll: { x: 800 },
+        internalHooks: INTERNAL_HOOKS,
+        tailor: true,
+      },
+    })
+
+    await flushResize()
+
+    const root = wrapper.get('.vc-table').element as HTMLElement
+    mockElementWidth(root, 320)
+    _rs?.([{ target: root } as ResizeObserverEntry])
+    await flushResize()
+
+    const fixedEmpty = wrapper.get('.vc-table-expanded-row-fixed')
+    expect(fixedEmpty.text()).toBe('No data')
+    expect(fixedEmpty.attributes('style')).toContain('width: 320px')
+    expect(fixedEmpty.attributes('style')).toContain('position: sticky')
+    expect(fixedEmpty.attributes('style')).toContain('left: 0px')
+
+    mockElementWidth(root, 480)
+    _rs?.([{ target: root } as ResizeObserverEntry])
+    await flushResize()
+
+    expect(fixedEmpty.attributes('style')).toContain('width: 480px')
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary

- pass the empty expanded-row content through `Cell`'s reactive `children` prop
- keep the measured sticky wrapper synchronized after `ResizeObserver` updates the table width
- add a regression test covering the initial measurement and a subsequent resize

## Root cause

`ExpandedRow` creates the viewport-width sticky wrapper only after `componentWidth` is measured. The content was forwarded through `Cell`'s default slot, while `Cell` memoizes its render result. The initial slot result was therefore cached before the width was available, so the sticky VNode did not reach the DOM.

Using the existing `children` prop makes the wrapper a tracked input of the memoized cell render. This preserves the Vue implementation details while matching rc-table / Ant Design behavior: the empty placeholder remains centered in the visible viewport during horizontal scrolling.

## Why use `children` instead of the default slot?

Vue explicitly documents that [the setup context and the properties of `slots` are not reactive](https://vuejs.org/api/composition-api-setup.html#setup-context). When a parent changes slot content, Vue schedules the child to render again; the slot object itself does not trigger reactive invalidation. This behavior is also described by a [Vue maintainer](https://github.com/vuejs/core/issues/4618#issuecomment-921629313).

The two forms are equivalent when the child consumes them directly, but not at this memoization boundary. `Cell` caches `computeContent()` in a Vue `computed`. In the slot form, the parent replaces a slot function that closes over the newly rendered `contentNode`; that slot replacement is not a reactive dependency of the child's computed, so it can keep returning the VNode cached before `componentWidth` was measured.

`props.children`, in contrast, is a declared reactive prop read by `computeContent`. When `ExpandedRow` creates the sticky VNode after measurement, the changed prop invalidates the computed value. The change therefore makes the dynamic VNode observable to the existing cache; it does not depend on slots and props having different visible rendering semantics. `Cell` already declares and prioritizes this prop, making it the smallest fix without weakening memoization or coupling `Cell` to table width state.

Vue has an [open discussion about making slots reactive in additional edge cases](https://github.com/vuejs/core/issues/11227), but that is not part of the current documented contract. This fix follows the current Vue behavior and does not depend on a future framework change.

## Validation

- `pnpm --filter @v-c/table test` — 9 files, 23 tests passed
- `pnpm exec eslint packages/table/src/Body/ExpandedRow.tsx packages/table/tests/empty-scroll.test.tsx`
- `pnpm --filter @v-c/table build`
- browser verification with a local `antdv-next` playground: the placeholder position remained fixed while the table scrolled horizontally

Closes #62


