### PR TITLE
fix(tabs): keep leaving pane visible during animated switch

### DIFF
--- a/packages/tabs/src/TabPanelList/index.vue
+++ b/packages/tabs/src/TabPanelList/index.vue
@@ -85,6 +85,11 @@ function shouldRender(item: Tab) {
       :style="bodyStyle"
     >
       <template v-for="item in tabs" :key="item.key">
+        <!--
+          动画模式下不能绑定 `-hidden`(display: none):它会在切换瞬间生效,
+          离场面板的 leave 过渡(绝对定位交叉淡出)会被直接杀掉。
+          隐藏交给 v-show 在 leave 结束后处理,对齐 rc-tabs 的 leavedClassName 时机。
+        -->
         <Transition v-if="tabPaneAnimated" v-bind="transitionProps">
           <TabPane
             v-if="shouldRender(item)"
@@ -95,7 +100,7 @@ function shouldRender(item: Tab) {
             :animated="tabPaneAnimated"
             :active="item.key === activeKey"
             :style="{ ...(contentStyle || {}), ...(item.style || {}) }"
-            :class-name="[contentClassName, item.className, item.key !== activeKey && `${tabPanePrefixCls}-hidden`]"
+            :class-name="[contentClassName, item.className]"
           >
             <RenderComponent :render="item.children" />
           </TabPane>

--- a/packages/tabs/src/TabPanelList/index.vue
+++ b/packages/tabs/src/TabPanelList/index.vue
@@ -88,12 +88,13 @@ function shouldRender(item: Tab) {
         <!--
           动画模式下不能绑定 `-hidden`(display: none):它会在切换瞬间生效,
           离场面板的 leave 过渡(绝对定位交叉淡出)会被直接杀掉。
-          隐藏交给 v-show 在 leave 结束后处理,对齐 rc-tabs 的 leavedClassName 时机。
+          可见性统一交给 v-show(含 forceRender 的非激活面板),由它在
+          leave 结束后写入 display:none,对齐 rc-tabs 的 leavedClassName 时机。
         -->
         <Transition v-if="tabPaneAnimated" v-bind="transitionProps">
           <TabPane
             v-if="shouldRender(item)"
-            v-show="shouldDestroyOnHidden(item) ? true : (item.key === activeKey || item.forceRender)"
+            v-show="shouldDestroyOnHidden(item) ? true : item.key === activeKey"
             :id="id"
             :prefix-cls="tabPanePrefixCls"
             :tab-key="item.key"

--- a/packages/tabs/tests/forceRender.spec.ts
+++ b/packages/tabs/tests/forceRender.spec.ts
@@ -73,6 +73,32 @@ describe('@v-c/tabs forceRender / lazy render', () => {
     expect(unmounted).toEqual([])
   })
 
+  it('hides an inactive forceRender pane when animated', () => {
+    const mounted: string[] = []
+    const T = makeTracker(mounted)
+    const items: NonNullable<TabsProps['items']> = [
+      { key: '1', label: 'tab 1', children: h(T('1')) },
+      { key: '2', label: 'tab 2', children: h(T('2')), forceRender: true },
+    ]
+
+    const wrapper = mount(Tabs, {
+      props: { activeKey: '1', items, animated: { tabPane: true, tabPaneMotion: { name: 'test-switch' } } },
+    })
+
+    // forceRender 面板保持挂载
+    expect(mounted.slice().sort()).toEqual(['1', '2'])
+
+    const panes = wrapper.findAll('[role="tabpanel"]')
+    expect(panes).toHaveLength(2)
+
+    // 非激活时必须不可见(由 v-show 隐藏,动画分支不再依赖 -hidden 类)
+    const hiddenPane = panes.find(p => p.attributes('aria-hidden') === 'true')!
+    expect((hiddenPane.element as HTMLElement).style.display).toBe('none')
+
+    const activePane = panes.find(p => p.attributes('aria-hidden') === 'false')!
+    expect((activePane.element as HTMLElement).style.display).not.toBe('none')
+  })
+
   it('destroyOnHidden unmounts the pane when it becomes inactive', async () => {
     const mounted: string[] = []
     const unmounted: string[] = []


### PR DESCRIPTION
## 问题

animated 模式下切换 tab，离场面板的交叉淡出被杀掉：`-hidden`（display: none）类是响应式绑定，activeKey 一变就立即生效，leave 过渡（绝对定位 + opacity 渐隐）作用在一个已经 display:none 的元素上——旧内容瞬间消失，只剩新内容单边淡入。rc-tabs 通过 `leavedClassName` 在动画结束后才加 hidden，行为不同。

对应下游反馈 antdv-next#660 中提到的切换动画异常。

## 修复

动画分支移除 `-hidden` 类绑定：v-show 本就会在 leave 过渡结束后写入 inline `display: none`，该类在动画模式下是冗余且有害的；非动画分支保留原样。

## 验证

- packages/tabs 全部 6 个测试通过
- 在 antdv-next playground 以 Chrome 逐帧采样验证：修复前离场面板 f0 即 `display:none`；修复后离场面板保持 `display:block; position:absolute`（与进入面板同位叠加）opacity 1→0 渐隐，进入面板同步 0→1，与 React antd 行为一致；快速往返切换（动画中断）无类名残留