### PR TITLE
fix(table): respect legacy rowSpan when calculating hover range

### DIFF
--- a/packages/table/src/Cell/index.tsx
+++ b/packages/table/src/Cell/index.tsx
@@ -364,7 +364,7 @@ const Cell = defineComponent<CellProps<any>>({
 
       const mergedColSpan = legacyCellProps?.colSpan ?? additionalProps.colSpan ?? colSpan ?? 1
       const mergedRowSpan = legacyCellProps?.rowSpan ?? additionalProps.rowSpan ?? rowSpan ?? 1
-      const mergedHoverRowSpan = hoverRowSpan ?? mergedRowSpan
+      const mergedHoverRowSpan = legacyCellProps?.rowSpan ?? hoverRowSpan ?? mergedRowSpan
 
       const [hovering, onHover] = useHoverState(index!, mergedHoverRowSpan, tableContext)
 

--- a/packages/table/tests/hover-expand-offset.test.tsx
+++ b/packages/table/tests/hover-expand-offset.test.tsx
@@ -29,10 +29,11 @@ describe('table hover with expandedRowOffset', () => {
       props: {
         columns,
         data,
-        expandable: { defaultExpandedRowKeys: ['1'], expandedRowOffset: 3 },
-      },
-      slots: {
-        expandedRowRender: ({ record }: any) => h('div', { class: 'expanded-content' }, record.description),
+        expandable: {
+          defaultExpandedRowKeys: ['1'],
+          expandedRowOffset: 3,
+          expandedRowRender: record => h('div', { class: 'expanded-content' }, record.description),
+        },
       },
     })
 
@@ -72,10 +73,11 @@ describe('table hover with expandedRowOffset', () => {
       props: {
         columns,
         data,
-        expandable: { defaultExpandedRowKeys: ['1', '2', '3', '4'], expandedRowOffset: 3 },
-      },
-      slots: {
-        expandedRowRender: ({ record }: any) => h('div', { class: 'expanded-content' }, record.description),
+        expandable: {
+          defaultExpandedRowKeys: ['1', '2', '3', '4'],
+          expandedRowOffset: 3,
+          expandedRowRender: record => h('div', { class: 'expanded-content' }, record.description),
+        },
       },
     })
 
@@ -94,6 +96,51 @@ describe('table hover with expandedRowOffset', () => {
     expect(notExpandableAgeCell!.classes()).toContain('vc-table-cell-row-hover')
     expect(teamACell!.classes()).not.toContain('vc-table-cell-row-hover')
     expect(jimNameCell!.classes()).not.toContain('vc-table-cell-row-hover')
+
+    wrapper.unmount()
+  })
+
+  it('uses legacy render rowSpan for the hover range', async () => {
+    const columns = [
+      Table.EXPAND_COLUMN,
+      {
+        title: 'Team',
+        dataIndex: 'team',
+        key: 'team',
+        render: (value: string, _record: any, index: number) => ({
+          children: value,
+          props: { rowSpan: index % 2 === 0 ? 2 : 0 },
+        }),
+      },
+      { title: 'Name', dataIndex: 'name', key: 'name' },
+    ]
+    const data = [
+      { key: '1', team: 'Team A', name: 'John' },
+      { key: '2', team: 'Team A', name: 'Jim' },
+    ]
+
+    const wrapper = mount(Table, {
+      props: {
+        columns,
+        data,
+        expandable: {
+          expandedRowOffset: 2,
+          expandedRowRender: record => h('div', record.name),
+        },
+      },
+    })
+
+    const firstRow = wrapper.find('tbody tr[data-row-key="1"]')
+    const secondRow = wrapper.find('tbody tr[data-row-key="2"]')
+    const teamCell = firstRow.findAll('td').find(cell => cell.text() === 'Team A')
+
+    expect(teamCell).toBeTruthy()
+    expect(teamCell!.attributes('rowspan')).toBe('2')
+
+    await teamCell!.trigger('mouseenter')
+    await nextTick()
+
+    expect(secondRow.findAll('td').some(cell => cell.classes().includes('vc-table-cell-row-hover'))).toBe(true)
 
     wrapper.unmount()
   })


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> N/A

### 💡 Background and Solution

> Background
> Chinese
>> - 修复 [expand-sticky PR](https://github.com/antdv-next/vue-components/pull/55) 中关于 table legacy render().props.rowSpan 的 hover 优先级被破坏问题

> English
>> - Fixed an issue in [expand-sticky PR](https://github.com/antdv-next/vue-components/pull/55) where the hover priority for `table legacy render().props.rowSpan` was broken.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed a broken hover priority for `table legacy render().props.rowSpan` |
| 🇨🇳 Chinese | 修复 table legacy render().props.rowSpan 的 hover 优先级被破坏 |
