### PR TITLE
fix(picker): disable attribute inheritance for panel components

### DIFF
--- a/packages/picker/src/PickerPanel/PanelBody.tsx
+++ b/packages/picker/src/PickerPanel/PanelBody.tsx
@@ -187,6 +187,7 @@ const PanelBody = defineComponent<PanelBodyProps<any>>(
   },
   {
     name: 'PanelBody',
+    inheritAttrs: false
   },
 )
 

--- a/packages/picker/src/PickerPanel/PanelHeader.tsx
+++ b/packages/picker/src/PickerPanel/PanelHeader.tsx
@@ -185,6 +185,7 @@ const PanelHeader = defineComponent<PanelHeaderProps<any>>(
   },
   {
     name: 'PanelHeader',
+    inheritAttrs: false
   },
 )
 


### PR DESCRIPTION
- Added inheritAttrs: false to PanelBody component
- Added inheritAttrs: false to PanelHeader component
- Prevents unwanted attribute passthrough to child elements
- Improves component encapsulation and styling control