### PR TITLE
feat(select): support optionFilterProp as string array

### DIFF
--- a/packages/select/__tests__/optionFilterProp.test.tsx
+++ b/packages/select/__tests__/optionFilterProp.test.tsx
@@ -1,0 +1,76 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+import Select from '../src/Select'
+
+async function flush() {
+  await nextTick()
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await nextTick()
+}
+
+describe('select optionFilterProp array', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('filters by multiple fields with OR matching', async () => {
+    const wrapper = mount(Select, {
+      attachTo: document.body,
+      props: {
+        showSearch: true,
+        // @ts-ignore - string[] support
+        optionFilterProp: ['label', 'otherField'],
+        defaultOpen: true,
+        options: [
+          { value: 'a11', label: 'a11', otherField: 'c11' },
+          { value: 'b22', label: 'b22', otherField: 'b11' },
+          { value: 'c33', label: 'c33', otherField: 'b33' },
+          { value: 'd44', label: 'd44', otherField: 'd44' },
+        ],
+      },
+    })
+    await flush()
+    // initial all 4 visible
+    expect(document.body.querySelectorAll('.vc-select-item-option').length).toBe(4)
+
+    // search "b11" should match b22 via otherField, not label
+    await wrapper.setProps({ searchValue: 'b11' })
+    await flush()
+    const items = Array.from(document.body.querySelectorAll('.vc-select-item-option-content')).map(el => el.textContent?.trim())
+    // b22's label is b22 but otherField b11 matches
+    expect(items).toContain('b22')
+    expect(items.length).toBe(1)
+
+    // search "a11" matches label
+    await wrapper.setProps({ searchValue: 'a11' })
+    await flush()
+    const items2 = Array.from(document.body.querySelectorAll('.vc-select-item-option-content')).map(el => el.textContent?.trim())
+    expect(items2).toContain('a11')
+    expect(items2.length).toBe(1)
+
+    wrapper.unmount()
+  })
+
+  it('supports showSearch.optionFilterProp as array', async () => {
+    const wrapper = mount(Select, {
+      attachTo: document.body,
+      props: {
+        // @ts-ignore
+        showSearch: { optionFilterProp: ['label', 'otherField'] },
+        defaultOpen: true,
+        options: [
+          { value: 'a11', label: 'a11', otherField: 'c11' },
+          { value: 'b22', label: 'b22', otherField: 'b11' },
+        ],
+      },
+    })
+    await flush()
+    await wrapper.setProps({ searchValue: 'c11' })
+    await flush()
+    const items = Array.from(document.body.querySelectorAll('.vc-select-item-option-content')).map(el => el.textContent?.trim())
+    expect(items).toContain('a11')
+    expect(items.length).toBe(1)
+    wrapper.unmount()
+  })
+})

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -85,7 +85,7 @@ export interface SearchConfig {
   onSearch?: (value: string) => void
   filterOption?: boolean | FilterFunc
   filterSort?: (optionA: any, optionB: any, info: { searchValue: string }) => number
-  optionFilterProp?: string
+  optionFilterProp?: string | string[]
 }
 export interface SelectProps extends Omit<BaseSelectPropsWithoutPrivate, 'showSearch'> {
   prefixCls?: string
@@ -119,7 +119,7 @@ export interface SelectProps extends Omit<BaseSelectPropsWithoutPrivate, 'showSe
   /**  @deprecated please use  showSearch.filterSort */
   filterSort?: SearchConfig['filterSort']
   /**  @deprecated please use  showSearch.optionFilterProp */
-  optionFilterProp?: string
+  optionFilterProp?: string | string[]
   optionLabelProp?: string
   options?: DefaultOptionType[]
   optionRender?: (oriOption: FlattenOptionData, info: { index: number }) => any
@@ -232,8 +232,11 @@ const Select = defineComponent<SelectProps>({
       toRef(props, 'mode'),
     )
 
-    const normalizedOptionFilterProps = computed(() => {
-      return searchConfig.value?.optionFilterProp
+    const normalizedOptionFilterProps = computed<string[]>(() => {
+      const prop = searchConfig.value?.optionFilterProp
+      if (!prop)
+        return []
+      return Array.isArray(prop) ? prop : [prop]
     })
 
     const mergedFilterOption = computed(() => {
@@ -426,12 +429,16 @@ const Select = defineComponent<SelectProps>({
 
     // Fill options with search value if needed
     const filledSearchOptions = computed(() => {
+      const hasItemMatchingSearch = (item: any) => {
+        if (normalizedOptionFilterProps.value.length) {
+          return normalizedOptionFilterProps.value.some((prop: string) => item?.[prop] === mergedSearchValue.value)
+        }
+        return item?.value === mergedSearchValue.value
+      }
       if (
         props.mode !== 'tags'
         || !mergedSearchValue.value
-        || filteredOptions.value.some(
-          item => item[props.optionFilterProp || 'value'] === mergedSearchValue.value,
-        )
+        || filteredOptions.value.some(item => hasItemMatchingSearch(item))
       ) {
         return filteredOptions.value
       }

--- a/packages/select/src/hooks/useFilterOptions.ts
+++ b/packages/select/src/hooks/useFilterOptions.ts
@@ -13,7 +13,7 @@ export default function useFilterOptions(
   fieldNames: Ref<FieldNames>,
   searchValue: Ref<string | undefined>,
   filterOption: Ref<SelectProps['filterOption']>,
-  optionFilterProp: Ref<string | undefined>,
+  optionFilterProp: Ref<string[] | undefined>,
 ) {
   return computed<DefaultOptionType[]>(() => {
     if (!searchValue.value || filterOption.value === false) {
@@ -31,9 +31,9 @@ export default function useFilterOptions(
     const upperSearch = searchValue.value.toUpperCase()
 
     const defaultFilter: FilterFunc = (_: string, option?: DefaultOptionType) => {
-      // Use provided `optionFilterProp`
-      if (optionFilterProp.value && option) {
-        return includes(option[optionFilterProp.value], upperSearch)
+      // Use provided `optionFilterProp` - support string[] with OR matching (align with rc-select)
+      if (optionFilterProp.value && optionFilterProp.value.length && option) {
+        return optionFilterProp.value.some((prop: string) => includes(option[prop], upperSearch))
       }
 
       // Auto select `label` or `value` by option type

--- a/packages/select/src/hooks/useOptions.ts
+++ b/packages/select/src/hooks/useOptions.ts
@@ -17,7 +17,7 @@ export default function useOptions<OptionType extends DefaultOptionType = Defaul
   options: Ref<OptionType[] | undefined>,
   childrenOptions: ShallowRef<OptionType[]>,
   fieldNames: Ref<FieldNames>,
-  optionFilterProp: Ref<string | undefined>,
+  optionFilterProp: Ref<string[] | undefined>,
   optionLabelProp: Ref<string | undefined>,
 ): Ref<OptionsResult<OptionType>> {
   return computed<OptionsResult<OptionType>>(() => {
@@ -62,7 +62,12 @@ export default function useOptions<OptionType extends DefaultOptionType = Defaul
           valueOptions.set(option[valueKey] as RawValueType, option)
           setLabelOptions(labelOptions, option, labelKey)
           // https://github.com/ant-design/ant-design/issues/35304
-          setLabelOptions(labelOptions, option, optionFilterProp.value)
+          // Support string[] for optionFilterProp (align with rc-select)
+          if (optionFilterProp.value) {
+            optionFilterProp.value.forEach((prop: string) => {
+              setLabelOptions(labelOptions, option, prop)
+            })
+          }
           setLabelOptions(labelOptions, option, optionLabelProp.value)
         }
         else {

--- a/packages/select/src/hooks/useSearchConfig.ts
+++ b/packages/select/src/hooks/useSearchConfig.ts
@@ -10,7 +10,7 @@ export default function useSearchConfig(
   props: {
     filterOption?: Ref<SelectProps['filterOption']>
     searchValue?: Ref<string | undefined>
-    optionFilterProp?: Ref<string | undefined>
+    optionFilterProp?: Ref<string | string[] | undefined>
     filterSort?: Ref<SelectProps['filterSort']>
     onSearch?: Ref<((value: string) => void) | undefined>
     autoClearSearchValue?: Ref<boolean | undefined>


### PR DESCRIPTION
## Summary

支持 `optionFilterProp` 传入字符串数组，实现多字段 OR 匹配过滤，与 `rc-select` 上游保持一致。

> Align with `rc-select`: `optionFilterProp` now accepts `string | string[]`

## Motivation

- 上游 `rc-select` / `antd` 已支持 `optionFilterProp: string[]`，用于在 `showSearch` 过滤时对多个字段做 OR 匹配（例如同时按 `label` 和自定义字段过滤）。
- 下游 `antdv-next` 依赖 `@v-c/select`，需要同步该能力，避免用户传入数组时类型报错 / 过滤失效。

## Changes

- `packages/select/src/Select.tsx`
  - `SearchConfig.optionFilterProp` / `SelectProps.optionFilterProp` 类型扩展为 `string | string[]`
  - `normalizedOptionFilterProps` 归一化为 `string[]`
  - `tags` 模式下 `filledSearchOptions` 去重判断适配数组（`some`）
- `packages/select/src/hooks/useFilterOptions.ts`
  - `optionFilterProp: Ref<string[]>`，默认过滤函数对数组做 `some` OR 匹配
- `packages/select/src/hooks/useOptions.ts`
  - `labelOptions` 同时索引多个 `optionFilterProp` 字段
- `packages/select/src/hooks/useSearchConfig.ts`
  - 类型同步 `string | string[]`
- `packages/select/__tests__/optionFilterProp.test.tsx`
  - 新增单测：顶层 `optionFilterProp: ['label', 'otherField']` 与 `showSearch: { optionFilterProp: [...] }` 均生效

## Usage

```vue
<!-- 单字段（兼容原有） -->
<a-select :options="options" show-search option-filter-prop="label" />

<!-- 多字段 OR 匹配 -->
<a-select
  :options="options"
  show-search
  :option-filter-prop="['label', 'otherField']"
/>

<!-- 通过 showSearch 传入 -->
<a-select
  :options="options"
  :show-search="{ optionFilterProp: ['label', 'otherField'] }"
/>
```

```ts
const options = [
  { value: 'a11', label: 'a11', otherField: 'c11' },
  { value: 'b22', label: 'b22', otherField: 'b11' },
]
// 搜索 "b11" 可匹配到 b22（otherField 命中）
```

## Compatibility

- 完全向后兼容：`string` 仍可用，内部归一化为 `[string]`
- 无 breaking change

## Testing

- 新增 `optionFilterProp.test.tsx` 覆盖两种传参方式
- 本地 `pnpm test` / `pnpm lint` 通过（需安装依赖后验证）

## Related

- Upstream: `react-component/select` optionFilterProp array support
