### PR TITLE
fix(select): freeze memoFlattenOptions during close to prevent filter flash

### DIFF
--- a/packages/select/__tests__/filterOptionFlash.test.tsx
+++ b/packages/select/__tests__/filterOptionFlash.test.tsx
@@ -1,0 +1,120 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+import Select from '../src/Select'
+
+async function flush() {
+  await nextTick()
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await nextTick()
+}
+
+describe('select filterOption flash fix', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('single select with custom filterOption should not flash all options when clicking filtered item', async () => {
+    const wrapper = mount(Select, {
+      attachTo: document.body,
+      props: {
+        showSearch: true,
+        defaultOpen: true,
+        filterOption: (input: string, option: any) =>
+          String(option.label).toLowerCase().includes(input.toLowerCase()),
+        options: [
+          { value: 'apple', label: 'Apple' },
+          { value: 'banana', label: 'Banana' },
+          { value: 'cherry', label: 'Cherry' },
+        ],
+      },
+    })
+    await flush()
+    await wrapper.setProps({ searchValue: 'ap' } as any)
+    await flush()
+
+    // Filtered by custom filterOption: 'ap' only matches Apple
+    expect(document.body.querySelectorAll('.vc-select-item-option').length).toBe(1)
+    expect(document.body.querySelector('.vc-select-item-option-content')?.textContent?.trim()).toBe('Apple')
+
+    // Click the filtered option
+    const optionEl = document.body.querySelector('.vc-select-item-option') as HTMLElement
+    optionEl.click()
+    await nextTick()
+
+    // During closing animation, memoFlattenOptions should stay frozen to filtered list
+    // (bug would restore to 3 options instantly before dropdown disappears)
+    expect(document.body.querySelectorAll('.vc-select-item-option').length).toBe(1)
+
+    // Wait for close macroTask + animation
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await nextTick()
+
+    wrapper.unmount()
+  })
+
+  it('single select with default filterOption should also freeze during close', async () => {
+    const wrapper = mount(Select, {
+      attachTo: document.body,
+      props: {
+        showSearch: true,
+        defaultOpen: true,
+        // no custom filterOption, use default
+        options: [
+          { value: 'apple', label: 'Apple' },
+          { value: 'banana', label: 'Banana' },
+          { value: 'cherry', label: 'Cherry' },
+        ],
+      },
+    })
+    await flush()
+    await wrapper.setProps({ searchValue: 'ap' } as any)
+    await flush()
+
+    // default filter: 'ap' matches Apple
+    expect(document.body.querySelectorAll('.vc-select-item-option').length).toBe(1)
+
+    const optionEl = document.body.querySelector('.vc-select-item-option') as HTMLElement
+    optionEl.click()
+    await nextTick()
+
+    expect(document.body.querySelectorAll('.vc-select-item-option').length).toBe(1)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await nextTick()
+    wrapper.unmount()
+  })
+
+  it('multiple mode should still clear search and show all options after select (not frozen forever)', async () => {
+    const wrapper = mount(Select, {
+      attachTo: document.body,
+      props: {
+        mode: 'multiple',
+        showSearch: true,
+        defaultOpen: true,
+        filterOption: (input: string, option: any) =>
+          String(option.label).toLowerCase().includes(input.toLowerCase()),
+        options: [
+          { value: 'apple', label: 'Apple' },
+          { value: 'banana', label: 'Banana' },
+          { value: 'cherry', label: 'Cherry' },
+        ],
+      },
+    })
+    await flush()
+    await wrapper.setProps({ searchValue: 'ap' } as any)
+    await flush()
+
+    expect(document.body.querySelectorAll('.vc-select-item-option').length).toBe(1)
+
+    const optionEl = document.body.querySelector('.vc-select-item-option') as HTMLElement
+    optionEl.click()
+    await flush()
+
+    // In multiple mode dropdown stays open and searchValue cleared, so all options visible
+    // This ensures our freeze does not block updates when open && !lock
+    expect(document.body.querySelectorAll('.vc-select-item-option').length).toBe(3)
+
+    wrapper.unmount()
+  })
+})

--- a/packages/select/src/OptionList.tsx
+++ b/packages/select/src/OptionList.tsx
@@ -43,11 +43,31 @@ const OptionList = defineComponent({
     const itemPrefixCls = computed(() => `${baseProps.value?.prefixCls}-item`)
 
     // Memoized flatten options (only update when open or options change)
+    // Align with rc-select: only update when open is true and not locked.
+    // This prevents the dropdown from flashing full options when searchValue is
+    // cleared synchronously on select (before the close animation finishes).
+    // See https://github.com/react-component/select/blob/master/src/OptionList.tsx
+    const cacheRef = shallowRef<{
+      value: FlattenOptionData<BaseOptionType>[]
+      condition: [boolean, boolean]
+    }>({
+      value: context.value?.flattenOptions || [],
+      condition: [!!baseProps.value?.open, !!baseProps.value?.lockOptions],
+    })
+
     const memoFlattenOptions = computed(() => {
-      if (!baseProps.value?.open) {
-        return context.value?.flattenOptions || []
+      const nextCondition: [boolean, boolean] = [
+        !!baseProps.value?.open,
+        !!baseProps.value?.lockOptions,
+      ]
+      const nextValue = context.value?.flattenOptions || []
+      const shouldUpdate = nextCondition[0] && !nextCondition[1]
+      if (shouldUpdate) {
+        // Only update cache when open && !lock, keep previous options during closing
+        cacheRef.value = { value: nextValue, condition: nextCondition }
+        return nextValue
       }
-      return context.value?.flattenOptions || []
+      return cacheRef.value.value
     })
 
     // =========================== List ===========================


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `next` branch.
-->

[中文版模板 / Chinese template](https://github.com/antdv-next/antdv-next/blob/main/.github/PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [x] 🐞 Bug fix
- [ ] 🆕 New feature
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Sync with upstream `react-component/select` behavior for `OptionList` memo logic.

Related to `rc-select` fix that prevents dropdown flicker when `searchValue` is cleared synchronously on select.

### 💡 Background and Solution

**Problem:**

In single `Select` with `showSearch` + `filterOption` (custom or default), typing a search term (e.g. `ap` -> only `Apple` visible) and clicking the filtered option triggers `searchValue` to be cleared synchronously before the dropdown close animation finishes. Previously `OptionList.memoFlattenOptions` directly returned `context.flattenOptions`, so it instantly restored the full option list (`Apple`, `Banana`, `Cherry`) during the closing phase, causing a visible flash.

**Solution:**

Align with `rc-select/src/OptionList.tsx`:
- Introduce `cacheRef` that caches the last `flattenOptions` value together with `[open, lockOptions]` condition.
- Only update the cache when `open === true && !lockOptions`. When the dropdown is closing (`open: false` or `lockOptions: true`), return the cached filtered list, freezing the dropdown content until it is fully hidden.

Rebased on `next` (includes `aria-posinset` / `renderHiddenItems` accessibility improvement # — `fix(select): announce option position in virtual mode`).

Added regression tests `filterOptionFlash.test.tsx`:
- `custom filterOption` single mode: click filtered item should not flash to 3 options
- `default filterOption` single mode: same expectation
- `multiple` mode: remains unfrozen (search cleared should still show all options after select)

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(select): freeze filtered options during dropdown close to prevent flash when `filterOption` is used |
| 🇨🇳 Chinese | fix(select): 修复使用 `filterOption` 时下拉关闭过程中选项闪回全部列表的问题，关闭动画期间冻结已过滤选项 |

