### PR TITLE
chore: ignore .pnpm-store in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+.pnpm-store
 dist
 dist-ssr
 *.local


### PR DESCRIPTION
### 🤔 This is a ...

- [x] ❓ Other (about what? chore: gitignore maintenance)

### 🔗 Related Issues

> - No related issue. 由本地 `pnpm` 产生的 `.pnpm-store/` 目录在 `git status` 中显示为 untracked，易误提交。

### 💡 Background and Solution

> - **Problem:** 本地执行 `pnpm` 相关操作后会产生 `.pnpm-store/` 目录，当前 `.gitignore` 未覆盖，导致 `git status` 常驻 `Untracked files: .pnpm-store/` 噪音，且有误提交风险。
> - **Solution:** 在 `.gitignore` 中 `node_modules` 之后新增 `.pnpm-store` 忽略规则（仅 1 行变更，基于 `next` 最新代码切出 `chore/gitignore-pnpm-store` 分支）。

### 📝 Change Log

> - 无用户侧 API / 行为变更，无需写入 Changelog。

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Ignore `.pnpm-store` directory in `.gitignore` to avoid untracked noise. |
| 🇨🇳 Chinese | 在 `.gitignore` 中忽略 `.pnpm-store` 目录，避免未跟踪文件干扰。 |