### PR TITLE
chore: align PR templates and workflows with antdv-next

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,51 @@
+<!--
+First of all, thank you for your contribution! 😄
+For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `next` branch.
+Before submitting your pull request, please make sure the checklist below is filled out.
+Your pull requests will be merged after one of the collaborators approves.
+Thank you!
+-->
+
+[中文版模板 / Chinese template](https://github.com/antdv-next/vue-components/blob/next/.github/PULL_REQUEST_TEMPLATE_CN.md)
+
+### 🤔 This is a ...
+
+- [ ] 🆕 New feature
+- [ ] 🐞 Bug fix
+- [ ] 📝 Site / documentation improvement
+- [ ] 📽️ Demo improvement
+- [ ] 💄 Component style improvement
+- [ ] 🤖 TypeScript definition improvement
+- [ ] 📦 Bundle size optimization
+- [ ] ⚡️ Performance optimization
+- [ ] ⭐️ Feature enhancement
+- [ ] 🌐 Internationalization
+- [ ] 🛠 Refactoring
+- [ ] 🎨 Code style optimization
+- [ ] ✅ Test Case
+- [ ] 🔀 Branch merge
+- [ ] ⏩ Workflow
+- [ ] ⌨️ Accessibility improvement
+- [ ] ❓ Other (about what?)
+
+### 🔗 Related Issues
+
+> - Describe the source of related requirements, such as links to relevant issue discussions.
+> - For example: close #xxxx, fix #xxxx
+
+### 💡 Background and Solution
+
+> - The specific problem to be addressed.
+> - List the final API implementation and usage if needed.
+> - If there are UI/interaction changes, consider providing screenshots or GIFs.
+
+### 📝 Change Log
+
+> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
+> - Describe the impact of the changes on developers, not the solution approach.
+> - Reference: https://keepachangelog.com/en/1.1.0/
+
+| Language   | Changelog |
+| ---------- | --------- |
+| 🇺🇸 English |           |
+| 🇨🇳 Chinese |           |

--- a/.github/PULL_REQUEST_TEMPLATE_CN.md
+++ b/.github/PULL_REQUEST_TEMPLATE_CN.md
@@ -1,0 +1,51 @@
+<!--
+首先，感谢你的贡献！😄
+如果你要提交新功能或修复 Bug，请基于 `next` 分支创建 feature/bugfix 分支后再提交。
+在提交 Pull Request 前，请确认下方清单已完成。
+Pull Request 会在至少一位协作者审核通过后合并。
+谢谢！
+-->
+
+[English template / 英文模板](https://github.com/antdv-next/vue-components/blob/next/.github/PULL_REQUEST_TEMPLATE.md)
+
+### 🤔 本次变更属于 ...
+
+- [ ] 🆕 新功能
+- [ ] 🐞 Bug 修复
+- [ ] 📝 站点 / 文档改进
+- [ ] 📽️ Demo 改进
+- [ ] 💄 组件样式改进
+- [ ] 🤖 TypeScript 类型定义改进
+- [ ] 📦 包体积优化
+- [ ] ⚡️ 性能优化
+- [ ] ⭐️ 功能增强
+- [ ] 🌐 国际化
+- [ ] 🛠 重构
+- [ ] 🎨 代码风格优化
+- [ ] ✅ 测试用例
+- [ ] 🔀 分支合并
+- [ ] ⏩ 工作流
+- [ ] ⌨️ 无障碍改进
+- [ ] ❓ 其他（请说明）
+
+### 🔗 相关 Issue
+
+> - 请说明需求来源，如相关 Issue 或讨论链接。
+> - 例如：close #xxxx, fix #xxxx
+
+### 💡 背景与方案
+
+> - 需要解决的具体问题是什么。
+> - 如有必要，请给出最终 API 设计与使用方式。
+> - 如果有 UI / 交互变化，建议提供截图或 GIF。
+
+### 📝 变更日志
+
+> - 建议阅读 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)。
+> - 变更日志应描述对开发者的影响，而不是实现过程。
+> - 参考：https://keepachangelog.com/en/1.1.0/
+
+| 语言 | 变更日志 |
+| ---- | -------- |
+| 🇺🇸 英文 |          |
+| 🇨🇳 中文 |          |

--- a/.github/workflows/semantic-pull-requests.yml
+++ b/.github/workflows/semantic-pull-requests.yml
@@ -1,0 +1,32 @@
+name: Validate PR title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions: {}
+
+jobs:
+  semantic-pr:
+    permissions:
+      contents: read
+      pull-requests: read # for amannn/action-semantic-pull-request to analyze PRs
+      statuses: write # for amannn/action-semantic-pull-request to mark status of analyzed PR
+    if: github.repository == 'antdv-next/vue-components'
+    runs-on: ubuntu-latest
+    name: 🏷️ Validate PR title
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@v6
+        with:
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Sync PR templates and workflows from `antdv-next` to keep contribution experience consistent across repos.

### 💡 Background and Solution

**Problem:** `vue-components` had no PR template and no semantic PR title validation, while `antdv-next` already has both. Contributors get inconsistent guidance and PR titles are not validated.

**Solution:**
- Add `.github/PULL_REQUEST_TEMPLATE.md` (EN) and `.github/PULL_REQUEST_TEMPLATE_CN.md` (CN) synced from `antdv-next/.github/PULL_REQUEST_TEMPLATE*.md`
  - adapt base branch `main` → `next`
  - adapt cross-links to `antdv-next/vue-components` repo
  - adapt changelog reference to generic Keep a Changelog (no dedicated site for vue-components)
- Add `.github/workflows/semantic-pull-requests.yml` synced from `antdv-next`
  - validates PR title follows Conventional Commits (`amannn/action-semantic-pull-request@v6`)
  - enforces `subjectPattern: ^(?![A-Z]).+$` (subject must not start with uppercase)
  - adapt repository guard to `antdv-next/vue-components`

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add PR templates and semantic PR title validation synced from antdv-next |
| 🇨🇳 Chinese | 新增 PR 模板与语义化标题校验，与 antdv-next 保持一致 |