### PR TITLE
fix(menu): generate stable unique ids

### DIFF
--- a/packages/menu/src/Menu.tsx
+++ b/packages/menu/src/Menu.tsx
@@ -173,7 +173,8 @@ const defaults = {
 const Menu = defineComponent<MenuProps>(
   (props = defaults, { slots, expose, attrs: _attrs }) => {
     const containerRef = shallowRef<HTMLUListElement>()
-    const uuid = useId(props?.id ? `vc-menu-uuid-${props.id}` : 'vc-menu-uuid')
+    const mergedId = useId()
+    const uuid = props.id ?? `vc-menu-uuid-${mergedId}`
     const isRtl = computed(() => props?.direction === 'rtl')
     const childList = shallowRef<any[]>([])
     const mergedOverflowIndicator = computed(

--- a/packages/menu/tests/id.spec.tsx
+++ b/packages/menu/tests/id.spec.tsx
@@ -1,0 +1,47 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { h } from 'vue'
+import Menu, { Item as MenuItem, SubMenu } from '../src'
+
+let id = 0
+
+vi.mock('@v-c/util/dist/hooks/useId', () => ({
+  default: (customId?: string) => customId ?? `mock-id-${++id}`,
+}))
+
+function createMenu(customId?: string) {
+  return mount(Menu, {
+    props: {
+      id: customId,
+      mode: 'inline',
+      openKeys: ['sub'],
+    },
+    slots: {
+      default: () => h(SubMenu, { key: 'sub', title: 'Submenu' }, {
+        default: () => h(MenuItem, { key: 'item' }, () => 'Item'),
+      }),
+    },
+  })
+}
+
+describe('menu ids', () => {
+  beforeEach(() => {
+    id = 0
+  })
+
+  it('generates distinct popup ids across menu instances', () => {
+    const first = createMenu()
+    const second = createMenu()
+    const firstPopupId = first.find('.vc-menu-submenu-title').attributes('aria-controls')
+    const secondPopupId = second.find('.vc-menu-submenu-title').attributes('aria-controls')
+
+    expect(firstPopupId).not.toBe(secondPopupId)
+  })
+
+  it('preserves a provided menu id', () => {
+    const wrapper = createMenu('custom-menu')
+
+    expect(wrapper.find('.vc-menu-submenu-title').attributes('aria-controls'))
+      .toBe('custom-menu-sub-popup')
+  })
+})


### PR DESCRIPTION
## Summary

- generate a stable unique menu id when id is omitted
- keep an explicitly supplied id unchanged
- add regression coverage for generated and explicit ids

## Upstream

- https://github.com/react-component/menu/pull/888
- https://github.com/react-component/menu/pull/889

## Verification

- menu tests: 20 passed
- lint passed