### PR TITLE
fix(notification): prevent close button form submission

### DIFF
--- a/packages/notification/src/Notification.tsx
+++ b/packages/notification/src/Notification.tsx
@@ -1,5 +1,5 @@
-import type { Component, CSSProperties, HTMLAttributes } from 'vue'
 import type { VueNode } from '@v-c/util/dist/type'
+import type { Component, CSSProperties, HTMLAttributes } from 'vue'
 import type { ClosableType } from './hooks/useClosable'
 import type { NotificationProgressProps } from './Progress'
 import { clsx } from '@v-c/util'
@@ -294,6 +294,7 @@ const Notification = defineComponent<NotificationProps>(
 
           {mergedClosable.value && (
             <button
+              type="button"
               class={clsx(`${noticePrefixCls}-close`, ncs?.close)}
               aria-label="Close"
               {...closeBtnAriaProps.value}

--- a/packages/notification/tests/notification.test.tsx
+++ b/packages/notification/tests/notification.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
-import { nextTick } from 'vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 import Notifications from '../src/Notifications'
 
 describe('notification', () => {
@@ -36,6 +36,28 @@ describe('notification', () => {
 
     expect(closableOnClose).toHaveBeenCalledTimes(1)
     expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the close control as a non-submit button', async () => {
+    const wrapper = mount(Notifications, {
+      props: {
+        container: document.body,
+      },
+      attachTo: document.body,
+    })
+
+    wrapper.vm.open({
+      key: 'notice',
+      title: 'Notice',
+      duration: false,
+      closable: true,
+    })
+
+    await nextTick()
+    await nextTick()
+
+    expect(document.querySelector<HTMLButtonElement>('.vc-notification-notice-close')?.type)
+      .toBe('button')
   })
 
   it('does not call notice close callbacks when closed by api', async () => {


### PR DESCRIPTION
## Summary

- set the notification close button type to button
- prevent accidental form submission when a notification is rendered inside a form
- add regression coverage

## Upstream

- https://github.com/react-component/notification/pull/408

## Verification

- notification tests: 3 passed
- lint passed