### PR TITLE
fix(steps): trigger click handlers from keyboard activation

### DIFF
--- a/packages/steps/src/Step.tsx
+++ b/packages/steps/src/Step.tsx
@@ -2,7 +2,6 @@ import type { KeyboardEventHandler, MouseEventHandler } from '@v-c/util/dist/Eve
 import type { VueNode } from '@v-c/util/dist/type'
 import type { Status, StepItem, StepsProps } from './Steps'
 import { clsx } from '@v-c/util'
-import KeyCode from '@v-c/util/dist/KeyCode'
 import { defineComponent } from 'vue'
 import { useStepsContext } from './Context'
 import Rail from './Rail.tsx'
@@ -114,9 +113,9 @@ const Step = defineComponent<StepProps>(
         }
 
         accessibilityProps.onKeydown = (e: KeyboardEvent) => {
-          const { which } = e
-          if (which === KeyCode.ENTER || which === KeyCode.SPACE) {
-            onClick?.(index)
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            e.currentTarget.click()
           }
         }
       }

--- a/packages/steps/tests/index.test.tsx
+++ b/packages/steps/tests/index.test.tsx
@@ -480,6 +480,7 @@ describe('steps', () => {
 
   it('key board support', async () => {
     const onChange = vitest.fn()
+    const onClick = vitest.fn()
     const wrapper = mount(
       <Steps
         current={0}
@@ -492,12 +493,14 @@ describe('steps', () => {
           {
             title: 'Waiting',
             description: 'This is a description',
+            onClick,
           },
         ]}
       />,
     )
 
-    await wrapper.findAll('[role="button"]')?.[1].trigger('keydown', { keyCode: 13 })
-    expect(onChange).toHaveBeenCalled()
+    await wrapper.findAll('[role="button"]')?.[1].trigger('keydown', { key: 'Enter' })
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onClick).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary

- activate clickable steps with Enter and Space
- route keyboard activation through the native click path so item and parent callbacks stay consistent
- prevent the default Space scrolling behavior

## Upstream

- https://github.com/react-component/steps/pull/395

## Verification

- targeted keyboard regression test passed
- lint passed

Note: the package full suite has pre-existing snapshot and DOM selector failures on next; snapshots were intentionally not rewritten in this PR.