### PR TITLE
fix(tooltip): support focus trigger and preserve aria-describedby

### DIFF
--- a/packages/tooltip/src/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip.tsx
@@ -63,7 +63,7 @@ const defaults = {
   mouseEnterDelay: 0,
   mouseLeaveDelay: 0.1,
   prefixCls: 'vc-tooltip',
-  trigger: ['hover'],
+  trigger: ['hover', 'focus'],
   placement: 'right',
   align: {},
   showArrow: true,
@@ -106,7 +106,7 @@ const Tooltip = defineComponent<TooltipProps>(
     })
     return () => {
       const {
-        trigger = ['hover'],
+        trigger = ['hover', 'focus'],
         mouseEnterDelay = 0,
         mouseLeaveDelay = 0.1,
         prefixCls = 'vc-tooltip',
@@ -131,8 +131,12 @@ const Tooltip = defineComponent<TooltipProps>(
       const getChildren = ({ open }: any) => {
         const children = filterEmpty(slots?.default?.({ open }))
         const child = children?.[0]
+        const childAriaDescribedBy = child?.props?.['aria-describedby']
+        const ariaDescribedBy = [childAriaDescribedBy, overlay && open ? mergedId : undefined]
+          .filter(Boolean)
+          .join(' ')
         const ariaProps = {
-          'aria-describedby': overlay && open ? mergedId : undefined,
+          'aria-describedby': ariaDescribedBy || undefined,
         }
         return createVNode(child, ariaProps)
       }

--- a/packages/tooltip/tests/disabled.test.tsx
+++ b/packages/tooltip/tests/disabled.test.tsx
@@ -32,6 +32,21 @@ function mountTooltip(props: Record<string, any> = {}) {
   )
 }
 
+function mountDescribedTooltip() {
+  return mount(
+    defineComponent({
+      setup() {
+        return () => (
+          <Tooltip visible overlay={<span>tip</span>}>
+            <span class="target" aria-describedby="existing-description">target</span>
+          </Tooltip>
+        )
+      },
+    }),
+    { attachTo: document.body },
+  )
+}
+
 describe('tooltip disabled', () => {
   it('forwards `disabled` to Trigger so the tooltip stays hidden', async () => {
     const wrapper = mountTooltip({ visible: true, disabled: true })
@@ -47,6 +62,29 @@ describe('tooltip disabled', () => {
     await settle()
 
     expect(popupVisible()).toBe(true)
+
+    wrapper.unmount()
+  })
+})
+
+describe('tooltip accessibility', () => {
+  it('opens on focus by default', async () => {
+    const wrapper = mountTooltip()
+
+    await wrapper.find('.target').trigger('focus')
+    await settle()
+
+    expect(popupVisible()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('preserves the child aria-describedby value', async () => {
+    const wrapper = mountDescribedTooltip()
+    await settle()
+
+    expect(wrapper.find('.target').attributes('aria-describedby'))
+      .toMatch(/^existing-description\s+.+/)
 
     wrapper.unmount()
   })


### PR DESCRIPTION
## Summary

- include focus in the default tooltip triggers
- preserve an existing child aria-describedby value
- merge tooltip and child description ids when both exist
- add regression coverage

## Upstream

- https://github.com/react-component/tooltip/pull/541
- https://github.com/react-component/tooltip/pull/542

## Verification

- tooltip tests: 6 passed
- lint passed