### PR TITLE
fix(async-validator): accept single-label URL hosts

### DIFF
--- a/packages/async-validator/src/rule/url.ts
+++ b/packages/async-validator/src/rule/url.ts
@@ -52,7 +52,7 @@ export default () => {
   const tld = `(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))`
   const port = '(?::\\d{2,5})?'
   const path = '(?:[/?#][^\\s"]*)?'
-  const regex = `(?:${protocol}|www\\.)${auth}(?:localhost|${ipv4}|${ipv6}|${host}${domain}${tld})${port}${path}`
+  const regex = `(?:${protocol}|www\\.)${auth}(?:localhost|${ipv4}|${ipv6}|${host}(?:${domain}${tld})?)${port}${path}`
   urlReg = new RegExp(`(?:^${regex}$)`, 'i')
   return urlReg
 }

--- a/packages/async-validator/tests/url.spec.ts
+++ b/packages/async-validator/tests/url.spec.ts
@@ -2,6 +2,21 @@ import { describe, expect, it } from 'vitest'
 import Schema from '../src'
 
 describe('url', () => {
+  it('works for a single-label host', () => {
+    new Schema({
+      v: {
+        type: 'url',
+      },
+    }).validate(
+      {
+        v: 'http://intranet/dashboard',
+      },
+      (errors) => {
+        expect(errors).toBe(null)
+      },
+    )
+  })
+
   it('works for empty string', () => {
     new Schema({
       v: {


### PR DESCRIPTION
## Summary

- allow valid URL values with a single-label hostname
- retain existing URL validation behavior
- add regression coverage

## Upstream

- https://github.com/react-component/async-validator/pull/30

## Verification

- async-validator tests: 117 passed