### PR TITLE
feat(segmented): add selected text class

### DIFF
--- a/packages/segmented/src/index.tsx
+++ b/packages/segmented/src/index.tsx
@@ -276,6 +276,7 @@ const Segmented = defineComponent<SegmentedProps>(
               segmentedClassNames?.item,
               {
                 [`${prefixCls}-item-selected`]: optionValue === mergedValue.value && !thumbShow.value,
+                [`${prefixCls}-item-selected-text`]: optionValue === mergedValue.value,
                 [`${prefixCls}-item-focused`]: isFocused.value && isKeyboard.value && optionValue === mergedValue.value,
               },
             )}

--- a/packages/segmented/tests/index.test.tsx
+++ b/packages/segmented/tests/index.test.tsx
@@ -4,6 +4,13 @@ import { nextTick } from 'vue'
 import Segmented from '../src'
 
 describe('segmented', () => {
+  it('marks selected item text independently from the animated thumb', () => {
+    const wrapper = mount(<Segmented value="b" options={['a', 'b', 'c']} />)
+
+    expect(wrapper.findAll('.vc-segmented-item')[1].classes())
+      .toContain('vc-segmented-item-selected-text')
+  })
+
   it('should select the first option by default when no value/defaultValue is provided', () => {
     const wrapper = mount(<Segmented options={['a', 'b', 'c']} />)
     const inputs = wrapper.findAll('.vc-segmented-item-input')


### PR DESCRIPTION
## Summary

- add a dedicated selected-text class to the active segmented label
- add regression coverage for the selected state class

## Upstream

- https://github.com/react-component/segmented/pull/342

## Verification

- segmented tests: 6 passed