### PR TITLE
feat(select): support input autocomplete

### DIFF
--- a/packages/select/__tests__/select.test.tsx
+++ b/packages/select/__tests__/select.test.tsx
@@ -15,6 +15,18 @@ describe('select react sync', () => {
     document.body.innerHTML = ''
   })
 
+  it('forwards autocomplete to the search input', () => {
+    const wrapper = mount(Select, {
+      props: {
+        showSearch: true,
+        autoComplete: 'organization-title',
+      },
+    })
+
+    expect(wrapper.find('input').attributes('autocomplete')).toBe('organization-title')
+    expect(wrapper.attributes('autocomplete')).toBeUndefined()
+  })
+
   it('does not add has-value class when selected label is empty string', async () => {
     const wrapper = mount(Select, {
       attachTo: document.body,

--- a/packages/select/src/BaseSelect/index.tsx
+++ b/packages/select/src/BaseSelect/index.tsx
@@ -138,6 +138,7 @@ export interface BaseSelectProps extends BaseSelectPrivateProps {
   tagRender?: (props: CustomTagProps) => any
   direction?: 'ltr' | 'rtl'
   autoFocus?: boolean
+  autoComplete?: string
   placeholder?: VueNode
   maxCount?: number
 

--- a/packages/select/src/SelectInput/Input.tsx
+++ b/packages/select/src/SelectInput/Input.tsx
@@ -153,6 +153,7 @@ const Input = defineComponent<InputProps>(
       const {
         prefixCls,
         autoFocus,
+        autoComplete: contextAutoComplete,
         placeholder,
       } = selectInputContext.value ?? {}
       const { input: InputComponent = 'input' } = selectInputContext.value?.components ?? {}
@@ -170,7 +171,7 @@ const Input = defineComponent<InputProps>(
 
       // ============================= Render =============================
       // Extract shared input props
-      
+
       const sharedInputProps = {
         id,
         'type': 'text',
@@ -183,7 +184,7 @@ const Input = defineComponent<InputProps>(
           '--select-input-width': widthCssVar.value,
         },
         autoFocus,
-        'autocomplete': autoComplete || 'new-password',
+        'autocomplete': autoComplete ?? contextAutoComplete ?? 'new-password',
         'class': inputCls,
         disabled,
         'value': value || '',

--- a/packages/select/src/SelectInput/index.tsx
+++ b/packages/select/src/SelectInput/index.tsx
@@ -42,6 +42,7 @@ export interface SelectInputProps {
   onSelectorRemove?: (value: DisplayValueType) => void
   maxLength?: number
   autoFocus?: boolean
+  autoComplete?: string
   /** Check if `tokenSeparators` contains `\n` or `\r\n` */
   tokenWithEnter?: boolean
   // Add other props that need to be passed through
@@ -70,6 +71,7 @@ const DEFAULT_OMIT_PROPS = [
   'onPopupScroll',
   'tabIndex',
   'activeValue',
+  'autoComplete',
   'onSelectorRemove',
   'focused',
 ] as const


### PR DESCRIPTION
## Summary

- expose autoComplete on Select and BaseSelect
- pass the value through select context to the search input
- keep new-password as the existing fallback
- add regression coverage

## Upstream

- https://github.com/react-component/select/pull/1250

## Verification

- select tests: 31 passed
- build passed
- lint passed