### PR TITLE
fix(tree): initialize drag data before onDragStart

### DIFF
--- a/packages/tree/src/TreeNode.tsx
+++ b/packages/tree/src/TreeNode.tsx
@@ -108,11 +108,11 @@ const TreeNode = defineComponent<TreeNodeProps>(
     const onDragStart = (e: DragEvent) => {
       e.stopPropagation()
       dragNodeHighlight.value = true
-      context.onNodeDragStart(e, props)
       try {
         e.dataTransfer?.setData('text/plain', '')
       }
       catch {}
+      context.onNodeDragStart(e, props)
     }
 
     const onDragEnter = (e: DragEvent) => {

--- a/packages/tree/tests/index.test.tsx
+++ b/packages/tree/tests/index.test.tsx
@@ -3,6 +3,26 @@ import { describe, expect, it, vi } from 'vitest'
 import Tree from '../src'
 
 describe('tree', () => {
+  it('preserves drag text set by consumers', async () => {
+    const dragData = new Map<string, string>()
+    const dataTransfer = {
+      setData: (type: string, value: string) => dragData.set(type, value),
+    }
+    const wrapper = mount(Tree, {
+      props: {
+        draggable: true,
+        treeData: [{ key: '0', title: 'node' }] as any,
+        onDragStart: ({ event }) => event.dataTransfer?.setData('text/plain', 'custom drag text'),
+      },
+    })
+
+    const event = new Event('dragstart', { bubbles: true })
+    Object.defineProperty(event, 'dataTransfer', { value: dataTransfer })
+    wrapper.get('.vc-tree-node-content-wrapper').element.dispatchEvent(event)
+
+    expect(dragData.get('text/plain')).toBe('custom drag text')
+  })
+
   it('supports switcher semantic styles and class names', () => {
     const wrapper = mount(() => (
       <Tree


### PR DESCRIPTION
## Summary

- initialize fallback drag data before invoking the consumer drag-start callback
- let consumers inspect the populated dataTransfer state from onDragStart
- add regression coverage

## Upstream

- https://github.com/react-component/tree/pull/1071

## Verification

- tree tests: 16 passed