### PR TITLE
fix(tree): calculate nested first-child drop position

### DIFF
--- a/packages/tree/src/util.ts
+++ b/packages/tree/src/util.ts
@@ -110,7 +110,9 @@ export function calcDropPosition<TreeDataType extends BasicDataNode = DataNode>(
   )
 
   let abstractDropNodeEntity = getEntity(keyEntities, targetNodeProps.eventKey!)
-  if (clientY < top + height / 2) {
+  const dropBeforeTarget = clientY < top + height / 2 && isFirstChild(abstractDropNodeEntity)
+
+  if (clientY < top + height / 2 && !dropBeforeTarget) {
     const nodeIndex = flattenedNodes.findIndex(({ key }) => key === abstractDropNodeEntity.key)
     const prevNodeKey = flattenedNodes[nodeIndex <= 0 ? 0 : nodeIndex - 1].key
     abstractDropNodeEntity = getEntity(keyEntities, prevNodeKey)
@@ -140,9 +142,7 @@ export function calcDropPosition<TreeDataType extends BasicDataNode = DataNode>(
   let dropAllowed = true
 
   if (
-    isFirstChild(abstractDropNodeEntity)
-    && abstractDropNodeEntity.level === 0
-    && clientY < top + height / 2
+    dropBeforeTarget
     && allowDrop({
       dragNode: abstractDragDataNode,
       dropNode: abstractDropDataNode,

--- a/packages/tree/tests/drop-position.test.ts
+++ b/packages/tree/tests/drop-position.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { calcDropPosition } from '../src/util'
+import { convertDataToEntities, fillFieldNames, flattenTreeData } from '../src/utils/treeUtil'
+
+describe('tree drop position', () => {
+  it('preserves a nested first child as the drop target', () => {
+    const treeData = [
+      {
+        key: 'parent',
+        title: 'parent',
+        children: [
+          { key: 'first', title: 'first' },
+          { key: 'second', title: 'second' },
+        ],
+      },
+      { key: 'drag', title: 'drag' },
+    ]
+    const { keyEntities } = convertDataToEntities(treeData)
+    const flattenedNodes = flattenTreeData(treeData, ['parent'], fillFieldNames())
+    const event = {
+      clientX: 0,
+      clientY: 5,
+      target: {
+        getBoundingClientRect: () => ({ top: 0, height: 20 }),
+      },
+    } as unknown as MouseEvent
+
+    const result = calcDropPosition(
+      event,
+      { eventKey: 'drag', data: treeData[1] } as any,
+      { eventKey: 'first', data: treeData[0].children![0] } as any,
+      24,
+      { x: 0, y: 0 },
+      () => true,
+      flattenedNodes,
+      keyEntities,
+      ['parent'],
+      'ltr',
+    )
+
+    expect(result).toMatchObject({
+      dropContainerKey: 'parent',
+      dropPosition: -1,
+      dropTargetKey: 'first',
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- handle drop-before positioning for a target nested as the first child
- preserve existing sibling drop calculations
- add regression coverage

## Upstream

- https://github.com/react-component/tree/pull/1070

## Verification

- tree tests: 16 passed
- lint passed