### PR TITLE
feat(cascader): support checkStrictly

### DIFF
--- a/packages/cascader/__tests__/check-strictly.test.tsx
+++ b/packages/cascader/__tests__/check-strictly.test.tsx
@@ -1,0 +1,47 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import Cascader from '../src'
+
+describe('cascader checkStrictly', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('selects child options independently', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount(Cascader, {
+      attachTo: document.body,
+      props: {
+        open: true,
+        checkable: true,
+        checkStrictly: true,
+        onChange,
+        options: [
+          {
+            label: 'Parent',
+            value: 'parent',
+            children: [{ label: 'Child', value: 'child' }],
+          },
+        ],
+      },
+    })
+
+    await nextTick()
+    const parent = document.body.querySelector<HTMLElement>('[data-path-key="parent"]')!
+    parent.click()
+    await nextTick()
+
+    const child = [...document.body.querySelectorAll<HTMLElement>('[role="menuitemcheckbox"]')]
+      .find(item => item.textContent?.includes('Child'))!
+    child.querySelector<HTMLElement>('.vc-cascader-checkbox')!.click()
+    await nextTick()
+
+    expect(onChange).toHaveBeenCalledWith(
+      [['parent', 'child']],
+      [[expect.objectContaining({ value: 'parent' }), expect.objectContaining({ value: 'child' })]],
+    )
+
+    wrapper.unmount()
+  })
+})

--- a/packages/cascader/src/Cascader.tsx
+++ b/packages/cascader/src/Cascader.tsx
@@ -93,6 +93,8 @@ interface BaseCascaderProps<
   changeOnSelect?: boolean
   displayRender?: (label: string[], selectedOptions?: OptionType[]) => VueNode
   checkable?: boolean | VueNode
+  /** Check each option independently without parent-child association. */
+  checkStrictly?: boolean
   showCheckedStrategy?: ShowCheckedStrategy
 
   // Search
@@ -220,6 +222,7 @@ const omitKeyList = [
   'changeOnSelect',
   'displayRender',
   'checkable',
+  'checkStrictly',
   'showCheckedStrategy',
 
   // Search
@@ -333,6 +336,7 @@ const Cascader = defineComponent<CascaderProps>(
     // Fill `rawValues` with checked conduction values
     const valuesInfo = useValues(
       multiple,
+      computed(() => !!props.checkStrictly),
       rawValues,
       getPathKeyEntities,
       getValueByKeyPath,
@@ -345,11 +349,13 @@ const Cascader = defineComponent<CascaderProps>(
 
     const deDuplicatedValues = computed(() => {
       const checkedKeys = toPathKeys(checkedValues.value)
-      const deduplicateKeys = formatStrategyValues(
-        checkedKeys,
-        getPathKeyEntities,
-        mergedShowCheckedStrategy.value,
-      )
+      const deduplicateKeys = props.checkStrictly
+        ? checkedKeys
+        : formatStrategyValues(
+            checkedKeys,
+            getPathKeyEntities,
+            mergedShowCheckedStrategy.value,
+          )
 
       return [...missingCheckedValues.value, ...getValueByKeyPath(deduplicateKeys)]
     })
@@ -386,6 +392,7 @@ const Cascader = defineComponent<CascaderProps>(
     // =========================== Select ===========================
     const handleSelection = useSelect(
       multiple,
+      computed(() => !!props.checkStrictly),
       triggerChange,
       checkedValues,
       halfCheckedValues,

--- a/packages/cascader/src/Panel.tsx
+++ b/packages/cascader/src/Panel.tsx
@@ -25,6 +25,7 @@ export type PickType
     | 'options'
     | 'prefixCls'
     | 'checkable'
+    | 'checkStrictly'
     | 'fieldNames'
     | 'showCheckedStrategy'
     | 'loadData'
@@ -87,6 +88,7 @@ const Panel = defineComponent<PanelProps>((props = panelDefaults) => {
   // Fill `rawValues` with checked conduction values
   const valuesInfo = useValues(
     multiple,
+    computed(() => !!props.checkStrictly),
     rawValues,
     getPathKeyEntities,
     getValueByKeyPath,
@@ -121,6 +123,7 @@ const Panel = defineComponent<PanelProps>((props = panelDefaults) => {
   // =========================== Select ===========================
   const handleSelection = useSelect(
     multiple,
+    computed(() => !!props.checkStrictly),
     triggerChange,
     checkedValues,
     halfCheckedValues,

--- a/packages/cascader/src/hooks/useSelect.ts
+++ b/packages/cascader/src/hooks/useSelect.ts
@@ -12,6 +12,7 @@ import { formatStrategyValues } from '../utils/treeUtil'
 
 export default function useSelect(
   multiple: Ref<boolean>,
+  checkStrictly: Ref<boolean>,
   triggerChange: (nextValues: InternalValueType) => void,
   checkedValues: Ref<SingleValueType[]>,
   halfCheckedValues: Ref<SingleValueType[]>,
@@ -44,6 +45,11 @@ export default function useSelect(
         nextMissingValues = missingCheckedValues.value.filter(
           valueCells => toPathKey(valueCells) !== pathKey,
         )
+      }
+      else if (checkStrictly.value) {
+        nextCheckedValues = existInChecked
+          ? checkedValues.value.filter(valueCells => toPathKey(valueCells) !== pathKey)
+          : [...checkedValues.value, valuePath]
       }
       else {
         // Update checked key first

--- a/packages/cascader/src/hooks/useValues.ts
+++ b/packages/cascader/src/hooks/useValues.ts
@@ -8,6 +8,7 @@ import { toPathKeys } from '../utils/commonUtil'
 
 export default function useValues(
   multiple: Ref<boolean>,
+  checkStrictly: Ref<boolean>,
   rawValues: Ref<SingleValueType[]>,
   getPathKeyEntities: () => Record<string, DataEntity>,
   getValueByKeyPath: (pathKeys: LegacyKey[]) => SingleValueType[],
@@ -26,6 +27,11 @@ export default function useValues(
     }
 
     const keyPathValues = toPathKeys(existValues)
+
+    if (checkStrictly.value) {
+      return [getValueByKeyPath(keyPathValues), [], missingValues]
+    }
+
     const keyPathEntities = getPathKeyEntities()
 
     const { checkedKeys, halfCheckedKeys } = conductCheck(keyPathValues, true, keyPathEntities) as {


### PR DESCRIPTION
## Summary

- add checkStrictly to Cascader and CascaderPanel
- select parent and child options independently when strict checking is enabled
- bypass parent-child conduction and checked-value deduplication in strict mode
- add regression coverage

## Upstream

- https://github.com/react-component/cascader/pull/662

## Verification

- cascader tests: 4 passed
- build passed
- changed-file lint passed