### PR TITLE
feat(table): support expand-all control

### DIFF
--- a/packages/table/docs/assets/index.less
+++ b/packages/table/docs/assets/index.less
@@ -265,13 +265,18 @@
   }
 
   &-row-expand-icon {
+    box-sizing: border-box;
     display: inline-block;
     width: 16px;
     height: 16px;
+    padding: 0;
     color: #aaa;
+    font: inherit;
     line-height: 16px;
     text-align: center;
     vertical-align: middle;
+    appearance: none;
+    background: transparent;
     border: 1px solid currentColor;
     cursor: pointer;
 

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -208,6 +208,7 @@ const Table = defineComponent<TableProps<DefaultRecordType>>((props = defaults, 
     mergedExpandIcon,
     mergedChildrenColumnName,
     onTriggerExpand,
+    expandAllInfo,
   ] = useExpand(props, mergedData, getRowKey)
 
   const componentWidth = ref(0)
@@ -225,6 +226,8 @@ const Table = defineComponent<TableProps<DefaultRecordType>>((props = defaults, 
       getRowKey,
       onTriggerExpand,
       expandIcon: mergedExpandIcon,
+      ExpandIcon: computed(() => props.components?.ExpandIcon),
+      expandAllInfo,
       rowExpandable: computed(() => expandableConfig.value.rowExpandable),
       expandIconColumnIndex: computed(() => expandableConfig.value.expandIconColumnIndex),
       expandedRowOffset: expandableConfig.value.expandedRowOffset,

--- a/packages/table/src/hooks/useColumns/index.tsx
+++ b/packages/table/src/hooks/useColumns/index.tsx
@@ -4,6 +4,9 @@ import type {
   ColumnsType,
   ColumnType,
   Direction,
+  ExpandColumnTitle,
+  ExpandIconComponent,
+  ExpandIconProps,
   FixedType,
   GetRowKey,
   Key,
@@ -12,8 +15,9 @@ import type {
 } from '../../interface'
 import { warning } from '@v-c/util'
 import { flattenChildren } from '@v-c/util/dist/props-util'
-import { computed, isVNode, toRaw, unref } from 'vue'
+import { computed, h, isVNode, toRaw, unref } from 'vue'
 import { EXPAND_COLUMN } from '../../constant'
+import { DefaultExpandIcon } from '../../utils/expandUtil'
 import { INTERNAL_COL_DEFINE } from '../../utils/legacyUtil'
 import useWidthColumns from './useWidthColumns'
 
@@ -102,10 +106,12 @@ export default function useColumns<RecordType>(
     children?: any
     expandable: Ref<boolean> | boolean
     expandedKeys: Ref<Set<Key>> | Set<Key>
-    columnTitle?: Ref<any> | any
+    columnTitle?: Ref<ExpandColumnTitle | undefined> | ExpandColumnTitle
     getRowKey: Ref<GetRowKey<RecordType>> | GetRowKey<RecordType>
     onTriggerExpand: TriggerEventHandler<RecordType>
     expandIcon?: Ref<RenderExpandIcon<RecordType> | undefined> | RenderExpandIcon<RecordType>
+    ExpandIcon?: Ref<ExpandIconComponent<RecordType> | undefined> | ExpandIconComponent<RecordType>
+    expandAllInfo?: Ref<Pick<ExpandIconProps<RecordType>, 'expanded' | 'expandable' | 'onClick'> | undefined>
     rowExpandable?: Ref<((record: RecordType) => boolean) | undefined> | ((record: RecordType) => boolean) | undefined
     expandIconColumnIndex?: Ref<number | undefined> | number
     expandedRowOffset?: number
@@ -175,12 +181,22 @@ export default function useColumns<RecordType>(
       }
 
       const prefixCls = unref(options.prefixCls) || ''
+      const MergedExpandIcon = unref(options.ExpandIcon) || DefaultExpandIcon
+      const expandAllInfo = unref(options.expandAllInfo)
+      const expandAllNode = expandAllInfo
+        ? h(MergedExpandIcon, { type: 'all', prefixCls, ...expandAllInfo } as any)
+        : undefined
+      const columnTitle = unref(options.columnTitle)
+      const mergedColumnTitle = typeof columnTitle === 'function'
+        ? (columnTitle as (props: { expandIcon: any }) => any)({ expandIcon: expandAllNode })
+        : (columnTitle ?? expandAllNode)
+
       const expandColumn = {
         [INTERNAL_COL_DEFINE]: {
           className: `${prefixCls}-expand-icon-col`,
           columnType: 'EXPAND_COLUMN',
         },
-        title: unref(options.columnTitle),
+        title: mergedColumnTitle,
         fixed: fixedColumn,
         className: `${prefixCls}-row-expand-icon-cell`,
         width: unref(options.columnWidth),

--- a/packages/table/src/hooks/useExpand.ts
+++ b/packages/table/src/hooks/useExpand.ts
@@ -2,6 +2,7 @@ import type { Ref } from 'vue'
 import type {
   ExpandableConfig,
   ExpandableType,
+  ExpandIconProps,
   GetRowKey,
   Key,
   RenderExpandIcon,
@@ -11,8 +12,13 @@ import type { TableProps } from '../Table'
 import { warning } from '@v-c/util'
 import { computed, ref, unref } from 'vue'
 import { INTERNAL_HOOKS } from '../constant'
-import { findAllChildrenKeys, renderExpandIcon } from '../utils/expandUtil'
+import { findAllChildrenKeys, renderExpandIcon, renderRowExpandIcon } from '../utils/expandUtil'
 import { getExpandableProps } from '../utils/legacyUtil'
+
+type ExpandAllInfo<RecordType> = Pick<
+  ExpandIconProps<RecordType>,
+  'expanded' | 'expandable' | 'onClick'
+>
 
 export default function useExpand<RecordType>(
   props: TableProps<RecordType>,
@@ -25,12 +31,17 @@ export default function useExpand<RecordType>(
   expandIcon: Ref<RenderExpandIcon<RecordType>>,
   childrenColumnName: Ref<string>,
   onTriggerExpand: TriggerEventHandler<RecordType>,
+  expandAllInfo: Ref<ExpandAllInfo<RecordType> | undefined>,
 ] {
   const expandableConfig = computed(() => getExpandableProps(props))
 
-  const mergedExpandIcon = computed<RenderExpandIcon<RecordType>>(
-    () => expandableConfig.value.expandIcon || renderExpandIcon,
-  )
+  const mergedExpandIcon = computed<RenderExpandIcon<RecordType>>(() => {
+    const customizeExpandIcon = props.components?.ExpandIcon
+    if (customizeExpandIcon) {
+      return iconProps => renderRowExpandIcon(customizeExpandIcon, iconProps)
+    }
+    return expandableConfig.value.expandIcon || renderExpandIcon
+  })
 
   const mergedChildrenColumnName = computed(
     () => expandableConfig.value.childrenColumnName || 'children',
@@ -100,6 +111,62 @@ export default function useExpand<RecordType>(
     event?.stopPropagation?.()
   }
 
+  const expandableRows = computed(() => {
+    if (!expandableConfig.value.showExpandAll || expandableType.value !== 'row') {
+      return []
+    }
+
+    const rowExpandable = expandableConfig.value.rowExpandable
+    return (unref(mergedData) || []).reduce<{ key: Key, record: RecordType }[]>(
+      (rows, record, index) => {
+        if (!rowExpandable || rowExpandable(record)) {
+          rows.push({ key: unref(getRowKey)(record, index), record })
+        }
+        return rows
+      },
+      [],
+    )
+  })
+
+  const allExpanded = computed(() =>
+    expandableRows.value.length > 0
+    && expandableRows.value.every(({ key }) => mergedExpandedKeys.value.has(key)),
+  )
+
+  const onTriggerExpandAll = (event: MouseEvent) => {
+    event.stopPropagation()
+    if (!expandableRows.value.length) {
+      return
+    }
+
+    const nextExpanded = !allExpanded.value
+    const nextExpandedKeys = new Set(mergedExpandedKeys.value)
+    expandableRows.value.forEach(({ key }) => {
+      if (nextExpanded) {
+        nextExpandedKeys.add(key)
+      }
+      else {
+        nextExpandedKeys.delete(key)
+      }
+    })
+
+    const keys = [...nextExpandedKeys]
+    innerExpandedKeys.value = keys
+    expandableConfig.value.onExpandAll?.(nextExpanded)
+    expandableConfig.value.onExpandedRowsChange?.(keys)
+    props['onUpdate:expandedRowKeys']?.(keys)
+  }
+
+  const expandAllInfo = computed<ExpandAllInfo<RecordType> | undefined>(() =>
+    expandableConfig.value.showExpandAll && expandableType.value === 'row'
+      ? {
+          expanded: allExpanded.value,
+          expandable: expandableRows.value.length > 0,
+          onClick: onTriggerExpandAll,
+        }
+      : undefined,
+  )
+
   if (
     process.env.NODE_ENV !== 'production'
     && expandableConfig.value.expandedRowRender
@@ -117,5 +184,6 @@ export default function useExpand<RecordType>(
     mergedExpandIcon as Ref<RenderExpandIcon<RecordType>>,
     mergedChildrenColumnName as Ref<string>,
     onTriggerExpand,
+    expandAllInfo,
   ]
 }

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -1,4 +1,4 @@
-import type { ColumnsType, ColumnType, DataIndex, ExpandableConfig, FixedType, GetComponentProps, GetRowKey, Reference, RenderedCell } from './interface'
+import type { ColumnsType, ColumnType, DataIndex, ExpandableConfig, ExpandIconComponent, ExpandIconProps, FixedType, GetComponentProps, GetRowKey, Reference, RenderedCell } from './interface'
 import type { TableProps } from './Table'
 import type { VirtualTableProps } from './VirtualTable'
 import { EXPAND_COLUMN, INTERNAL_HOOKS } from './constant'
@@ -12,6 +12,8 @@ import VirtualTable from './VirtualTable'
 export type {
   DataIndex,
   ExpandableConfig,
+  ExpandIconComponent,
+  ExpandIconProps,
   FixedType,
   GetComponentProps,
   GetRowKey,

--- a/packages/table/src/interface.ts
+++ b/packages/table/src/interface.ts
@@ -15,7 +15,7 @@ import type { VueNode } from '@v-c/util'
  * - onFilter
  * - onFilterDropdownVisibleChange
  */
-import type { CSSProperties, HTMLAttributes, Ref, TdHTMLAttributes } from 'vue'
+import type { CSSProperties, HTMLAttributes, Ref, TdHTMLAttributes, Component as VueComponent } from 'vue'
 import type { DeepNamePath } from './namePathType'
 
 export type Key = string | number
@@ -185,6 +185,7 @@ export type CustomizeScrollBody<RecordType = Record<string, any>> = (
 ) => any
 
 export interface TableComponents<RecordType> {
+  ExpandIcon?: ExpandIconComponent<RecordType>
   table?: CustomizeComponent
   header?: {
     table?: CustomizeComponent
@@ -256,21 +257,48 @@ export type RenderExpandIcon<RecordType> = (
   props: RenderExpandIconProps<RecordType>,
 ) => any
 
+export type ExpandIconProps<RecordType> = {
+  prefixCls: string
+  expanded: boolean
+  expandable: boolean
+  onClick: (event: MouseEvent) => void
+} & (
+  | {
+    type: 'row'
+    record: RecordType
+  }
+  | {
+    type: 'all'
+    record?: never
+  }
+)
+
+export type ExpandIconComponent<RecordType> = VueComponent<ExpandIconProps<RecordType>>
+
+export interface ExpandColumnTitleProps {
+  expandIcon: VueNode
+}
+
+export type ExpandColumnTitle = VueNode | ((props: ExpandColumnTitleProps) => VueNode)
+
 export interface ExpandableConfig<RecordType> {
   expandedRowKeys?: readonly Key[]
   defaultExpandedRowKeys?: readonly Key[]
   expandedRowRender?: ExpandedRowRender<RecordType>
   forceRender?: boolean
-  columnTitle?: VueNode
+  columnTitle?: ExpandColumnTitle
   expandRowByClick?: boolean
+  /** @deprecated Please use `components.ExpandIcon` instead. This only customizes row icons. */
   expandIcon?: RenderExpandIcon<RecordType>
   onExpand?: (expanded: boolean, record: RecordType) => void
+  onExpandAll?: (expanded: boolean) => void
   onExpandedRowsChange?: (expandedKeys: readonly Key[]) => void
   defaultExpandAllRows?: boolean
   indentSize?: number
   /** @deprecated Please use `EXPAND_COLUMN` in `columns` directly */
   expandIconColumnIndex?: number
   showExpandColumn?: boolean
+  showExpandAll?: boolean
   expandedRowClassName?: string | RowClassName<RecordType>
   childrenColumnName?: string
   rowExpandable?: (record: RecordType) => boolean

--- a/packages/table/src/utils/expandUtil.tsx
+++ b/packages/table/src/utils/expandUtil.tsx
@@ -1,5 +1,46 @@
-import type { ExpandableConfig, GetRowKey, Key, RenderExpandIconProps } from '../interface'
+import type {
+  ExpandableConfig,
+  ExpandIconComponent,
+  ExpandIconProps,
+  GetRowKey,
+  Key,
+  RenderExpandIconProps,
+} from '../interface'
 import { clsx } from '@v-c/util'
+import { h } from 'vue'
+
+export function DefaultExpandIcon<RecordType>({
+  prefixCls,
+  type,
+  onClick,
+  expanded,
+  expandable,
+}: ExpandIconProps<RecordType>) {
+  const expandClassName = `${prefixCls}-row-expand-icon`
+
+  if (!expandable) {
+    return <span class={clsx(expandClassName, `${prefixCls}-row-spaced`)} />
+  }
+
+  const className = clsx(expandClassName, {
+    [`${prefixCls}-row-expanded`]: expanded,
+    [`${prefixCls}-row-collapsed`]: !expanded,
+  })
+
+  if (type === 'all') {
+    return (
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-label={expanded ? 'Collapse all rows' : 'Expand all rows'}
+        class={className}
+        onClick={onClick}
+      />
+    )
+  }
+
+  return <span class={className} onClick={onClick} />
+}
 
 export function renderExpandIcon<RecordType>({
   prefixCls,
@@ -8,26 +49,41 @@ export function renderExpandIcon<RecordType>({
   expanded,
   expandable,
 }: RenderExpandIconProps<RecordType>) {
-  const expandClassName = `${prefixCls}-row-expand-icon`
-
-  if (!expandable) {
-    return <span class={clsx(expandClassName, `${prefixCls}-row-spaced`)} />
-  }
-
   const onClick = (event: MouseEvent) => {
     onExpand(record, event)
     event.stopPropagation()
   }
 
   return (
-    <span
-      class={clsx(expandClassName, {
-        [`${prefixCls}-row-expanded`]: expanded,
-        [`${prefixCls}-row-collapsed`]: !expanded,
-      })}
+    <DefaultExpandIcon
+      type="row"
+      prefixCls={prefixCls}
+      record={record}
+      expanded={expanded}
+      expandable={!!expandable}
       onClick={onClick}
     />
   )
+}
+
+export function renderRowExpandIcon<RecordType>(
+  ExpandIcon: ExpandIconComponent<RecordType>,
+  props: RenderExpandIconProps<RecordType>,
+) {
+  const { prefixCls, record, onExpand, expanded, expandable } = props
+  const onClick = (event: MouseEvent) => {
+    onExpand(record, event)
+    event.stopPropagation()
+  }
+
+  return h(ExpandIcon, {
+    type: 'row',
+    prefixCls,
+    record,
+    expanded,
+    expandable: !!expandable,
+    onClick,
+  } as any)
 }
 
 export function findAllChildrenKeys<RecordType>(

--- a/packages/table/tests/expand-all.test.tsx
+++ b/packages/table/tests/expand-all.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { h } from 'vue'
+import Table from '../src'
+
+describe('table expand all', () => {
+  it('expands and collapses every expandable row from the column header', async () => {
+    const onExpandAll = vi.fn()
+    const onExpandedRowsChange = vi.fn()
+    const wrapper = mount(Table, {
+      props: {
+        columns: [{ title: 'Name', dataIndex: 'name' }],
+        data: [
+          { key: '1', name: 'First' },
+          { key: '2', name: 'Second' },
+        ],
+        expandable: {
+          showExpandAll: true,
+          rowExpandable: (record: any) => record.key === '1',
+          expandedRowRender: (record: any) => h('div', `Details for ${record.name}`),
+          columnTitle: ({ expandIcon }: any) => h('div', { class: 'expand-all-title' }, [expandIcon]),
+          onExpandAll,
+          onExpandedRowsChange,
+        },
+      },
+    })
+
+    const expandAll = wrapper.find('thead button[aria-label="Expand all rows"]')
+    expect(expandAll.exists()).toBe(true)
+
+    await expandAll.trigger('click')
+    expect(wrapper.findAll('.vc-table-expanded-row')).toHaveLength(1)
+    expect(wrapper.find('thead button').attributes('aria-expanded')).toBe('true')
+    expect(onExpandAll).toHaveBeenLastCalledWith(true)
+    expect(onExpandedRowsChange).toHaveBeenLastCalledWith(['1'])
+
+    await wrapper.find('thead button').trigger('click')
+    expect(wrapper.find('.vc-table-expanded-row').attributes('style')).toContain('display: none')
+    expect(onExpandAll).toHaveBeenLastCalledWith(false)
+    expect(onExpandedRowsChange).toHaveBeenLastCalledWith([])
+
+    wrapper.unmount()
+  })
+
+  it('uses components.ExpandIcon for row and expand-all controls', () => {
+    const ExpandIcon = (props: any) => h('button', {
+      class: `custom-expand-${props.type}`,
+      onClick: props.onClick,
+    })
+    const wrapper = mount(Table, {
+      props: {
+        columns: [{ title: 'Name', dataIndex: 'name' }],
+        components: { ExpandIcon },
+        data: [{ key: '1', name: 'First' }],
+        expandable: {
+          showExpandAll: true,
+          expandedRowRender: () => 'Details',
+        },
+      },
+    })
+
+    expect(wrapper.find('.custom-expand-all').exists()).toBe(true)
+    expect(wrapper.find('.custom-expand-row').exists()).toBe(true)
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary

- add a showExpandAll header control for expandable rows
- support custom expand icons for row and expand-all controls through components.ExpandIcon
- support functional expansion column titles and onExpandAll
- respect rowExpandable when toggling all rows
- add regression coverage and reset button styling

## Upstream

- https://github.com/react-component/table/pull/1505

## Verification

- table tests: 35 passed
- build passed
- lint passed