### PR TITLE
fix(segmented): [sync] avoid selected item text color lagging behind thumb motion (#37192)

### DIFF
--- a/packages/segmented/docs/assets/index.less
+++ b/packages/segmented/docs/assets/index.less
@@ -47,6 +47,10 @@
       color: @text-color;
     }
 
+    &-selected-text {
+      color: @text-color;
+    }
+
     &:hover,
     &:focus {
       color: @text-color;


### PR DESCRIPTION
## Summary

Synchronized from upstream react-component/segmented.

- Upstream PR: https://github.com/react-component/segmented/pull/342
- Upstream commit: `2174553d001329b828ba208cd94aa82d4f58f31f`
- Validation: all configured commands passed

Generated by RepoSync Hub.