### PR TITLE
feat(select): [sync] support search input autocomplete overrides

### DIFF
--- a/packages/select/__tests__/select.test.tsx
+++ b/packages/select/__tests__/select.test.tsx
@@ -15,6 +15,16 @@ describe('select react sync', () => {
     document.body.innerHTML = ''
   })
 
+  it('suppresses browser autocomplete on the search input by default', () => {
+    const wrapper = mount(Select, {
+      props: {
+        showSearch: true,
+      },
+    })
+
+    expect(wrapper.find('input').attributes('autocomplete')).toBe('new-password')
+  })
+
   it('forwards autocomplete to the search input', () => {
     const wrapper = mount(Select, {
       props: {


### PR DESCRIPTION
## Summary

Synchronized from upstream react-component/select.

- Upstream PR: https://github.com/react-component/select/pull/1250
- Upstream commit: `0128e29ea13ced2495d003af0879755657366c51`
- Validation: all configured commands passed

Generated by RepoSync Hub.