### PR TITLE
feat(table): [sync] support expand all control in expandable column header

### DIFF
--- a/packages/table/src/interface.ts
+++ b/packages/table/src/interface.ts
@@ -219,7 +219,7 @@ export interface LegacyExpandableProps<RecordType> {
   expandedRowRender?: ExpandedRowRender<RecordType>
   /** @deprecated Use `expandable.expandRowByClick` instead */
   expandRowByClick?: boolean
-  /** @deprecated Use `expandable.expandIcon` instead */
+  /** @deprecated Use `components.ExpandIcon` instead */
   expandIcon?: RenderExpandIcon<RecordType>
   /** @deprecated Use `expandable.onExpand` instead */
   onExpand?: (expanded: boolean, record: RecordType) => void

--- a/packages/table/tests/expand-all.test.tsx
+++ b/packages/table/tests/expand-all.test.tsx
@@ -46,8 +46,9 @@ describe('table expand all', () => {
 
   it('uses components.ExpandIcon for row and expand-all controls', () => {
     const ExpandIcon = (props: any) => h('button', {
-      class: `custom-expand-${props.type}`,
-      onClick: props.onClick,
+      'class': `custom-expand-${props.type}`,
+      'data-record-key': props.record?.key,
+      'onClick': props.onClick,
     })
     const wrapper = mount(Table, {
       props: {
@@ -57,12 +58,114 @@ describe('table expand all', () => {
         expandable: {
           showExpandAll: true,
           expandedRowRender: () => 'Details',
+          expandIcon: () => h('span', { class: 'legacy-expand-icon' }),
         },
       },
     })
 
     expect(wrapper.find('.custom-expand-all').exists()).toBe(true)
+    expect(wrapper.find('.custom-expand-all').attributes('data-record-key')).toBeUndefined()
     expect(wrapper.find('.custom-expand-row').exists()).toBe(true)
+    expect(wrapper.find('.custom-expand-row').attributes('data-record-key')).toBe('1')
+    expect(wrapper.find('.legacy-expand-icon').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('only renders the default expand-all control when enabled', async () => {
+    const wrapper = mount(Table, {
+      props: {
+        columns: [{ title: 'Name', dataIndex: 'name' }],
+        data: [{ key: '1', name: 'First' }],
+        expandable: { expandedRowRender: () => 'Details' },
+      },
+    })
+
+    expect(wrapper.find('thead .vc-table-row-expand-icon').exists()).toBe(false)
+
+    await wrapper.setProps({
+      expandable: { showExpandAll: true, expandedRowRender: () => 'Details' },
+    })
+
+    const control = wrapper.find('thead button.vc-table-row-expand-icon')
+    expect(control.attributes('type')).toBe('button')
+    expect(control.attributes('aria-expanded')).toBe('false')
+    expect(control.attributes('aria-label')).toBe('Expand all rows')
+
+    await control.trigger('click')
+    expect(control.attributes('aria-expanded')).toBe('true')
+    expect(control.attributes('aria-label')).toBe('Collapse all rows')
+    wrapper.unmount()
+  })
+
+  it('does nothing when no rows are expandable', async () => {
+    const onExpandAll = vi.fn()
+    const onExpandedRowsChange = vi.fn()
+    const wrapper = mount(Table, {
+      props: {
+        columns: [{ title: 'Name', dataIndex: 'name' }],
+        data: [{ key: '1', name: 'First' }],
+        components: {
+          ExpandIcon: (props: any) => props.type === 'all'
+            ? h('button', {
+                'class': 'custom-expand-all',
+                'data-expandable': props.expandable,
+                'onClick': props.onClick,
+              })
+            : null,
+        },
+        expandable: {
+          showExpandAll: true,
+          expandedRowRender: () => 'Details',
+          rowExpandable: () => false,
+          onExpandAll,
+          onExpandedRowsChange,
+        },
+      },
+    })
+
+    const control = wrapper.find('.custom-expand-all')
+    expect(control.attributes('data-expandable')).toBe('false')
+    await control.trigger('click')
+    expect(onExpandAll).not.toHaveBeenCalled()
+    expect(onExpandedRowsChange).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('preserves unrelated keys with controlled expandedRowKeys', async () => {
+    const onExpandedRowsChange = vi.fn()
+    const wrapper = mount(Table, {
+      props: {
+        columns: [{ title: 'Name', dataIndex: 'name' }],
+        data: [
+          { key: '1', name: 'First' },
+          { key: '2', name: 'Second' },
+        ],
+        expandable: {
+          showExpandAll: true,
+          expandedRowKeys: ['unrelated'],
+          expandedRowRender: () => 'Details',
+          onExpandedRowsChange,
+        },
+      },
+    })
+
+    const control = wrapper.find('thead button')
+    await control.trigger('click')
+    expect(onExpandedRowsChange).toHaveBeenLastCalledWith(['unrelated', '1', '2'])
+    expect(control.attributes('aria-expanded')).toBe('false')
+
+    await wrapper.setProps({
+      expandable: {
+        showExpandAll: true,
+        expandedRowKeys: ['unrelated', '1', '2'],
+        expandedRowRender: () => 'Details',
+        onExpandedRowsChange,
+      },
+    })
+    expect(control.attributes('aria-expanded')).toBe('true')
+
+    await control.trigger('click')
+    expect(onExpandedRowsChange).toHaveBeenLastCalledWith(['unrelated'])
     wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Summary

Synchronized from upstream react-component/table.

- Upstream PR: https://github.com/react-component/table/pull/1505
- Upstream commit: `b94684617d318c127acb4ae7f88dc33d4907b889`
- Validation: all configured commands passed

Generated by RepoSync Hub.