### PR TITLE
fix(steps): [sync] preserve item click on keyboard activation

### DIFF
--- a/packages/steps/tests/index.test.tsx
+++ b/packages/steps/tests/index.test.tsx
@@ -499,8 +499,17 @@ describe('steps', () => {
       />,
     )
 
-    await wrapper.findAll('[role="button"]')?.[1].trigger('keydown', { key: 'Enter' })
-    expect(onChange).toHaveBeenCalledTimes(1)
-    expect(onClick).toHaveBeenCalledTimes(1)
+    const button = wrapper.findAll('[role="button"]')?.[1].element
+    const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true })
+    const spaceEvent = new KeyboardEvent('keydown', { key: ' ', cancelable: true })
+
+    button.dispatchEvent(enterEvent)
+    button.dispatchEvent(spaceEvent)
+
+    expect(onChange).toHaveBeenNthCalledWith(1, 1)
+    expect(onChange).toHaveBeenNthCalledWith(2, 1)
+    expect(onClick).toHaveBeenCalledTimes(2)
+    expect(enterEvent.defaultPrevented).toBe(true)
+    expect(spaceEvent.defaultPrevented).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- synchronize the keyboard activation regression coverage from react-component/steps#395
- verify both Enter and Space activate the clickable step
- verify keyboard handlers prevent the browser default action

Upstream: https://github.com/react-component/steps/pull/395

## Validation

- `pnpm --dir packages/steps test --run -t "key board support"` (passed)
- `pnpm --dir packages/steps build` (passed; the workspace currently reports pre-existing missing @v-c/util type diagnostics)
- `git diff --check` (passed)

The full package test command still reports pre-existing snapshot and legacy DOM-selector failures outside this change.