### PR TITLE
fix(progress): [sync] allow overriding SVG accessibility semantics

### DIFF
--- a/packages/progress/src/Circle/index.tsx
+++ b/packages/progress/src/Circle/index.tsx
@@ -159,6 +159,7 @@ const Circle = defineComponent<ProgressProps>(
       }
       return (
         <svg
+          role="presentation"
           {...omit(restProps, ['gapDegree', 'steps', 'percent', 'strokeLinecap', 'strokeColor'])}
           {...restAttrs}
           class={[`${prefixCls}-circle`, classNames.root, className]}
@@ -170,7 +171,6 @@ const Circle = defineComponent<ProgressProps>(
             }
           }
           id={id}
-          role="presentation"
         >
           {!stepCount && (
             <circle

--- a/packages/progress/src/Line.tsx
+++ b/packages/progress/src/Line.tsx
@@ -51,6 +51,7 @@ const Line = defineComponent<ProgressProps>(
       let stackPtg = 0
       return (
         <svg
+          role="presentation"
           {...restProps}
           {...restAttrs}
           class={{
@@ -61,7 +62,6 @@ const Line = defineComponent<ProgressProps>(
           viewBox={viewBoxString}
           style={style}
           id={id}
-          role="presentation"
         >
           <path
             class={[

--- a/packages/progress/tests/index.spec.tsx
+++ b/packages/progress/tests/index.spec.tsx
@@ -21,8 +21,22 @@ describe('progress semantics', () => {
     expect(wrapper.find(railSelector).attributes('stroke-width')).toBe('0')
   })
 
-  it('forwards accessible SVG attributes to line progress', () => {
+  it('uses presentational semantics for decorative progress', () => {
     const wrapper = mount(Line, {
+      props: {
+        prefixCls: 'vc-progress',
+        percent: 50,
+      },
+    })
+
+    expect(wrapper.attributes('role')).toBe('presentation')
+  })
+
+  it.each([
+    ['line', Line],
+    ['circle', Circle],
+  ])('forwards explicit accessible SVG semantics to %s progress', (_, Component) => {
+    const wrapper = mount(Component, {
       props: {
         id: 'upload-progress',
         prefixCls: 'vc-progress',
@@ -30,13 +44,20 @@ describe('progress semantics', () => {
       },
       attrs: {
         'aria-label': 'Upload progress',
+        'aria-valuemax': '100',
+        'aria-valuemin': '0',
+        'aria-valuenow': '50',
+        'role': 'progressbar',
       },
     })
 
     expect(wrapper.attributes()).toMatchObject({
       'aria-label': 'Upload progress',
+      'aria-valuemax': '100',
+      'aria-valuemin': '0',
+      'aria-valuenow': '50',
       'id': 'upload-progress',
-      'role': 'presentation',
+      'role': 'progressbar',
     })
   })
 })


### PR DESCRIPTION
## Summary

Synchronized from upstream react-component/progress.

- Upstream PR: https://github.com/react-component/progress/pull/325
- Upstream commit: `d25eac82c4ffdebc65b9fc674b4c545b4a29f2f4`
- Validation: all configured commands passed

Generated by RepoSync Hub.