### PR TITLE
fix(tree): [sync] prevent scroll on title descendant focus

### DIFF
--- a/packages/tree/src/Tree.tsx
+++ b/packages/tree/src/Tree.tsx
@@ -467,7 +467,12 @@ const Tree = defineComponent<TreeProps>(
     }
 
     function onFocus(e: FocusEvent) {
-      if (!focusedByMouse && !mergedDisabled.value && activeKey.value === null) {
+      if (
+        e.target === e.currentTarget
+        && !focusedByMouse
+        && !mergedDisabled.value
+        && activeKey.value === null
+      ) {
         const visibleSelectedKey = selectedKeys.value.find((key) => {
           return flattenNodes.value.some(nodeItem => nodeItem.key === key)
         })

--- a/packages/tree/tests/index.test.tsx
+++ b/packages/tree/tests/index.test.tsx
@@ -79,4 +79,36 @@ describe('tree', () => {
     expect(onMouseDown).toHaveBeenCalledTimes(1)
     expect(onActiveChange).not.toHaveBeenCalled()
   })
+
+  it.each([
+    { description: 'a selected node', treeProps: { selectedKeys: ['1'] } },
+    { description: 'selection disabled', treeProps: { selectable: false } },
+  ])('does not activate when a title descendant receives focus with $description', async ({ treeProps }) => {
+    const onActiveChange = vi.fn()
+    const onFocus = vi.fn()
+    const wrapper = mount(() => (
+      <Tree
+        treeData={Array.from({ length: 20 }, (_, index) => ({
+          key: String(index),
+          title: `Node ${index}`,
+        })) as any}
+        height={100}
+        itemHeight={20}
+        titleRender={node => node.key === '0'
+          ? <select aria-label="Node action"><option>Action</option></select>
+          : node.title}
+        onActiveChange={onActiveChange}
+        onFocus={onFocus}
+        {...treeProps}
+      />
+    ))
+
+    const select = wrapper.get('select')
+    await select.trigger('mousedown')
+    window.dispatchEvent(new MouseEvent('mouseup'))
+    select.element.dispatchEvent(new FocusEvent('focus', { bubbles: true }))
+
+    expect(onFocus).toHaveBeenCalledTimes(1)
+    expect(onActiveChange).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary

Synchronized from upstream react-component/tree.

- Upstream PR: https://github.com/react-component/tree/pull/1063
- Upstream commit: `2492cbcd2a43587f8e3b9b989c8ff569b99a3fd1`
- Validation: all configured commands passed

Generated by RepoSync Hub.