### PR TITLE
feat(menu): [sync] support SubMenu self-node semantics

### DIFF
--- a/packages/menu/src/SubMenu/index.tsx
+++ b/packages/menu/src/SubMenu/index.tsx
@@ -20,9 +20,10 @@ import PopupTrigger from './PopupTrigger'
 import SubMenuList from './SubMenuList'
 
 export type SemanticName = 'list' | 'listTitle'
+export type SubSemanticName = SemanticName | 'subItem' | 'subItemTitle'
 export interface SubMenuProps extends Omit<SubMenuType, 'key' | 'children' | 'label' | 'title'> {
-  classes?: Partial<Record<SemanticName, string>>
-  styles?: Partial<Record<SemanticName, CSSProperties>>
+  classes?: Partial<Record<SubSemanticName, string>>
+  styles?: Partial<Record<SubSemanticName, CSSProperties>>
   title?: VueNode
   /** Native `title` attribute for the submenu title element. */
   itemTitle?: string
@@ -251,8 +252,8 @@ const InternalSubMenu = defineComponent<SubMenuProps>(
       let titleNode = (
         <div
           role="menuitem"
-          style={directionStyle.value}
-          class={`${subMenuPrefixCls.value}-title`}
+          style={{ ...directionStyle.value, ...styles?.subItemTitle }}
+          class={classNames(`${subMenuPrefixCls.value}-title`, classes?.subItemTitle)}
           tabindex={mergedDisabled.value ? undefined : -1}
           title={itemTitle ?? (typeof title === 'string' ? title : undefined)}
           data-menu-id={overflowDisabled.value && domDataId.value ? undefined : domDataId.value}
@@ -320,10 +321,11 @@ const InternalSubMenu = defineComponent<SubMenuProps>(
           {...attrs as any}
           {...restProps}
           component="li"
-          style={style}
+          style={{ ...styles?.subItem, ...style }}
           class={classNames(
             subMenuPrefixCls.value,
             `${subMenuPrefixCls.value}-${mode.value}`,
+            classes?.subItem,
             className,
             {
               [`${subMenuPrefixCls.value}-open`]: open.value,

--- a/packages/menu/tests/semantic.spec.tsx
+++ b/packages/menu/tests/semantic.spec.tsx
@@ -1,0 +1,45 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { h } from 'vue'
+import Menu, { Item as MenuItem, SubMenu } from '../src'
+
+describe('semantic', () => {
+  it('supports classes and styles for SubMenu self nodes', () => {
+    const classes = {
+      subItem: 'test-sub-item',
+      subItemTitle: 'test-sub-item-title',
+    }
+    const styles = {
+      subItem: { width: '200px' },
+      subItemTitle: { whiteSpace: 'normal' as const },
+    }
+    const createSubMenu = (key: string, title: string, children: () => any) =>
+      h(SubMenu, { key, title, classes, styles }, { default: children })
+
+    const wrapper = mount(Menu, {
+      props: {
+        mode: 'inline',
+        openKeys: ['s1', 's1-2'],
+      },
+      slots: {
+        default: () => createSubMenu('s1', 'submenu1', () =>
+          createSubMenu('s1-2', 'submenu1-1', () =>
+            h(MenuItem, { key: 's1-2-1' }, () => '2-1'))),
+      },
+    })
+
+    const subItems = wrapper.findAll('.vc-menu-submenu')
+    const subItemTitles = wrapper.findAll('.vc-menu-submenu-title')
+
+    expect(subItems).toHaveLength(2)
+    expect(subItemTitles).toHaveLength(2)
+    subItems.forEach((subItem) => {
+      expect(subItem.classes()).toContain(classes.subItem)
+      expect(subItem.attributes('style')).toContain('width: 200px')
+    })
+    subItemTitles.forEach((subItemTitle) => {
+      expect(subItemTitle.classes()).toContain(classes.subItemTitle)
+      expect(subItemTitle.attributes('style')).toContain('white-space: normal')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Synchronized from upstream react-component/menu.

- Upstream PR: 
- Upstream commit: `843858e949389e5f74fd1667e6d204baefda42d6`
- Validation: all configured commands passed

Generated by RepoSync Hub.