### PR TITLE
fix(tooltip): [sync] describe falsy overlay content

### DIFF
--- a/packages/tooltip/src/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip.tsx
@@ -132,7 +132,7 @@ const Tooltip = defineComponent<TooltipProps>(
         const children = filterEmpty(slots?.default?.({ open }))
         const child = children?.[0]
         const childAriaDescribedBy = child?.props?.['aria-describedby']
-        const ariaDescribedBy = [childAriaDescribedBy, overlay && open ? mergedId : undefined]
+        const ariaDescribedBy = [childAriaDescribedBy, overlay != null && open ? mergedId : undefined]
           .filter(Boolean)
           .join(' ')
         const ariaProps = {

--- a/packages/tooltip/tests/disabled.test.tsx
+++ b/packages/tooltip/tests/disabled.test.tsx
@@ -101,4 +101,27 @@ describe('tooltip accessibility', () => {
 
     wrapper.unmount()
   })
+
+  it('sets aria-describedby for a falsy but valid overlay', async () => {
+    const wrapper = mountTooltip({ visible: true, overlay: 0 })
+    await settle()
+
+    const describedBy = wrapper.find('.target').attributes('aria-describedby')
+    expect(describedBy).toBeTruthy()
+    expect(document.getElementById(describedBy!)?.textContent).toBe('0')
+
+    wrapper.unmount()
+  })
+
+  it.each([null, undefined])(
+    'does not set aria-describedby for a nullish overlay',
+    async (overlay) => {
+      const wrapper = mountTooltip({ visible: true, overlay })
+      await settle()
+
+      expect(wrapper.find('.target').attributes('aria-describedby')).toBeUndefined()
+
+      wrapper.unmount()
+    },
+  )
 })


### PR DESCRIPTION
## Summary

Synchronized from upstream react-component/tooltip.

- Upstream PR: https://github.com/react-component/tooltip/pull/544
- Upstream commit: `2d2edbbab11bfc5bb525675ff61acd87ba71742e`
- Validation: all configured commands passed

Generated by RepoSync Hub.